### PR TITLE
Fix "Invalid" exceptions

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -5,7 +5,7 @@ Get["https://raw.githubusercontent.com/jkuczm/MathematicaBootstrapInstaller/v0.1
 
 BootstrapInstall[
 	"CellsToTeX",
-	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.0/CellsToTeX.zip"
+	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.1/CellsToTeX.zip"
 	,
 	{{
 		"SyntaxAnnotations",

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -884,14 +884,14 @@ SetAttributes[throwException, HoldFirst]
 
 throwException[
 	HoldComplete[thrownBy_] | thrownBy_,
-	{"Unsupported", elementType_},
+	{"Unsupported", elementType_, subTypes___},
 	(List | HoldComplete)[unsupported_, supported_],
 	messageName:(_String | Automatic):Automatic
 ] :=
 	With[{supportedPretty = prettifyPatterns /@ supported},
 		throwException[
 			thrownBy,
-			{"Unsupported", elementType},
+			{"Unsupported", elementType, subTypes},
 			HoldComplete[elementType, unsupported, supportedPretty],
 			messageName
 		]
@@ -907,6 +907,19 @@ throwException[
 		thrownBy,
 		{"Missing", elementType, subTypes},
 		HoldComplete[elementType, missing, available],
+		messageName
+	]
+
+throwException[
+	HoldComplete[thrownBy_] | thrownBy_,
+	{"Invalid", elementType_, subTypes___},
+	(List | HoldComplete)[boxes_],
+	messageName:(_String | Automatic):Automatic
+] :=
+	throwException[
+		thrownBy,
+		{"Invalid", elementType, subTypes},
+		HoldComplete[elementType, boxes],
 		messageName
 	]
 

--- a/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
+++ b/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
@@ -148,6 +148,7 @@ Test[
 					HoldForm @
 						toInputFormProcessor[{"Boxes" -> RowBox[{"f", "["}]}],
 					HoldForm @ CellsToTeXException["Invalid", "Boxes"],
+					HoldForm @ "Boxes",
 					HoldForm @ RowBox[{"f", "["}]
 				}
 			]

--- a/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
+++ b/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
@@ -114,6 +114,7 @@ Test[
 				"MessageParameters" -> {
 					HoldForm @ boxesToInputFormBoxes[RowBox[{"f", "["}]],
 					HoldForm @ CellsToTeXException["Invalid", "Boxes"],
+					HoldForm @ "Boxes",
 					HoldForm @ RowBox[{"f", "["}]
 				}
 			]

--- a/CellsToTeX/Tests/Unit/throwException.mt
+++ b/CellsToTeX/Tests/Unit/throwException.mt
@@ -325,6 +325,190 @@ Module[{thrownBy, errType},
 
 
 (* ::Subsection:: *)
+(*Known exceptions*)
+
+
+Module[{thrownBy, elementType, subType, expr},
+	Test[
+		Catch[
+			throwException[thrownBy, {"Failed", elementType, subType}, {expr}];
+			,
+			_
+			,
+			HoldComplete
+		]
+		,
+		HoldComplete @@ {
+			Failure[CellsToTeXException["Failed", elementType, subType],
+				Association[
+					"MessageTemplate" :> CellsToTeXException::failed,
+					"MessageParameters" -> {
+						HoldForm[thrownBy],
+						HoldForm @ CellsToTeXException[
+							"Failed", elementType, subType
+						],
+						HoldForm[expr]
+					}
+				]
+			],
+			CellsToTeXException["Failed", elementType, subType]
+		}
+		,
+		TestID -> "Known exception: Failed"
+	]
+]
+
+
+Module[{thrownBy, elementType, subType, missing, available},
+	Test[
+		Catch[
+			throwException[thrownBy, {"Missing", elementType, subType},
+				{missing, available}
+			];
+			,
+			_
+			,
+			HoldComplete
+		]
+		,
+		HoldComplete @@ {
+			Failure[CellsToTeXException["Missing", elementType, subType],
+				Association[
+					"MessageTemplate" :> CellsToTeXException::missing,
+					"MessageParameters" -> {
+						HoldForm[thrownBy],
+						HoldForm @ CellsToTeXException[
+							"Missing", elementType, subType
+						],
+						HoldForm[elementType],
+						HoldForm[missing],
+						HoldForm[available]
+					}
+				]
+			],
+			CellsToTeXException["Missing", elementType, subType]
+		}
+		,
+		TestID -> "Known exception: Missing"
+	]
+]
+
+
+Module[{thrownBy, elementType, subType, invalid},
+	Test[
+		Catch[
+			throwException[thrownBy, {"Invalid", elementType, subType},
+				{invalid}
+			];
+			,
+			_
+			,
+			HoldComplete
+		]
+		,
+		HoldComplete @@ {
+			Failure[CellsToTeXException["Invalid", elementType, subType],
+				Association[
+					"MessageTemplate" :> CellsToTeXException::invalid,
+					"MessageParameters" -> {
+						HoldForm[thrownBy],
+						HoldForm @ CellsToTeXException[
+							"Invalid", elementType, subType
+						],
+						HoldForm[elementType],
+						HoldForm[invalid]
+					}
+				]
+			],
+			CellsToTeXException["Invalid", elementType, subType]
+		}
+		,
+		TestID -> "Known exception: Invalid"
+	]
+]
+
+
+Module[
+	{
+		thrownBy, elementType, subType, unsupported, supported,
+		prettifyPatternsResult, $prettifyPatternsLog = {}
+	},
+	Block[{prettifyPatterns},
+		mockFunction[prettifyPatterns,
+			$prettifyPatternsLog, prettifyPatternsResult
+		];
+		
+		Test[
+			Catch[
+				throwException[thrownBy, {"Unsupported", elementType, subType},
+					{{unsupported}, {supported}}
+				];
+				,
+				_
+				,
+				HoldComplete
+			]
+			,
+			HoldComplete @@ {
+				Failure[
+					CellsToTeXException["Unsupported", elementType, subType],
+					Association[
+						"MessageTemplate" :> CellsToTeXException::unsupported,
+						"MessageParameters" -> {
+							HoldForm[thrownBy],
+							HoldForm @ CellsToTeXException[
+								"Unsupported", elementType, subType
+							],
+							HoldForm[elementType],
+							HoldForm[{unsupported}],
+							HoldForm[{prettifyPatternsResult}]
+						}
+					]
+				],
+				CellsToTeXException["Unsupported", elementType, subType]
+			}
+			,
+			TestID -> "Known exception: Unsupported"
+		]
+	]
+]
+
+
+Module[{thrownBy, elementType, subType, val1, val2},
+	Test[
+		Catch[
+			throwException[thrownBy, {"Error", elementType, subType},
+				{val1, val2}
+			];
+			,
+			_
+			,
+			HoldComplete
+		]
+		,
+		HoldComplete @@ {
+			Failure[CellsToTeXException["Error", elementType, subType],
+				Association[
+					"MessageTemplate" :> CellsToTeXException::error,
+					"MessageParameters" -> {
+						HoldForm[thrownBy],
+						HoldForm @ CellsToTeXException[
+							"Error", elementType, subType
+						],
+						HoldForm[val1],
+						HoldForm[val2]
+					}
+				]
+			],
+			CellsToTeXException["Error", elementType, subType]
+		}
+		,
+		TestID -> "Known exception: Error"
+	]
+]
+
+
+(* ::Subsection:: *)
 (*Incorrect arguments*)
 
 

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,10 +1,10 @@
 (* Paclet Info File *)
 
-(* created 2015/03/27*)
+(* created 2015/03/30*)
 
 Paclet[
     Name -> "CellsToTeX",
-    Version -> "0.1.0",
+    Version -> "0.1.1",
     MathematicaVersion -> "6+",
     Description -> "Convert Mathematica cells to TeX, retaining formatting",
     Creator -> "Jakub Kuczmarski",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To load CellsToTeX package evaluate: ``Needs["CellsToTeX`"]``.
 ### Manual installation
 
 1. Download latest released
-   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.0/CellsToTeX.zip)
+   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.1/CellsToTeX.zip)
    file.
 
 2. Extract downloaded `CellsToTeX.zip` to any directory which is on


### PR DESCRIPTION
Automatically add element type to "Invalid" exception's "MessageParameters" in `throwException` function.