### PR TITLE
Fix InputForm conversion of manually formatted boxes

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -5,7 +5,7 @@ Get["https://raw.githubusercontent.com/jkuczm/MathematicaBootstrapInstaller/v0.1
 
 BootstrapInstall[
 	"CellsToTeX",
-	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.2/CellsToTeX.zip"
+	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.3/CellsToTeX.zip"
 	,
 	{{
 		"SyntaxAnnotations",

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1164,7 +1164,7 @@ boxesToInputFormBoxes[
 
 functionCall:boxesToInputFormBoxes[boxes_] :=
 	Module[{expr, str, newBoxes},
-		expr = MakeExpression[boxes, StandardForm];
+		expr = MakeExpression[StripBoxes[boxes], StandardForm];
 		If[Head[expr] =!= HoldComplete,
 			throwException[functionCall, {"Invalid", "Boxes"}, {boxes}]
 		];

--- a/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
+++ b/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
@@ -156,6 +156,8 @@ Test[
 		CellsToTeXException["Invalid", "Boxes"]
 	}
 	,
+	Message[Syntax::bktmcp, DisplayForm[RowBox[List["f", "["]]], "]", "", ""]
+	,
 	TestID -> "Exception: Invalid Boxes"
 ]
 

--- a/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
+++ b/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
@@ -28,6 +28,30 @@ UsingFrontEnd @ Test[
 ]
 
 
+UsingFrontEnd @ Test[
+	RowBox[{"a", "+", "b", "  "}] // boxesToInputFormBoxes
+	,
+	RowBox[{"a", " ", "+", " ", "b"}]
+	,
+	TestID -> "RowBox: Plus with non-semantic whitespace"
+]
+
+UsingFrontEnd @ Test[
+	RowBox[{
+		"f", "[", "\[IndentingNewLine]",
+		RowBox[{
+			SuperscriptBox["x", "2"], ",", "\[IndentingNewLine]",
+			"y"
+		}], "\[IndentingNewLine]",
+		"]"
+	}] // boxesToInputFormBoxes
+	,
+	RowBox[{"f", "[", RowBox[{RowBox[{"x", "^", "2"}], ",", " ", "y"}], "]"}]
+	,
+	TestID -> "RowBox, nested, SuperscriptBox: \
+function, two args, newlines between args and next to brackets"
+]
+
 Test[
 	" " // boxesToInputFormBoxes
 	,
@@ -121,6 +145,8 @@ Test[
 		],
 		CellsToTeXException["Invalid", "Boxes"]
 	}
+	,
+	Message[Syntax::bktmcp, DisplayForm[RowBox[List["f", "["]]], "]", "", ""]
 	,
 	TestID -> "Exception: Invalid Boxes"
 ]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,10 +1,10 @@
 (* Paclet Info File *)
 
-(* created 2015/09/11*)
+(* created 2015/11/03*)
 
 Paclet[
     Name -> "CellsToTeX",
-    Version -> "0.1.2",
+    Version -> "0.1.3",
     MathematicaVersion -> "6+",
     Description -> "Convert Mathematica cells to TeX, retaining formatting",
     Creator -> "Jakub Kuczmarski",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To load CellsToTeX package evaluate: ``Needs["CellsToTeX`"]``.
 ### Manual installation
 
 1. Download latest released
-   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.2/CellsToTeX.zip)
+   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.3/CellsToTeX.zip)
    file.
 
 2. Extract downloaded `CellsToTeX.zip` to any directory which is on


### PR DESCRIPTION
Non-semantic box elements are now stripped before passing boxes to `MakeExpression`.

`MakeExpression` can ignore some of them, but some, like whitespace characters next to square brackets in expressions with more than one argument, cause errors.

Fixes #4.