### PR TITLE
Fix handling of options of formatting boxes

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -5,7 +5,7 @@ Get["https://raw.githubusercontent.com/jkuczm/MathematicaBootstrapInstaller/v0.1
 
 BootstrapInstall[
 	"CellsToTeX",
-	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.3/CellsToTeX.zip"
+	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.4/CellsToTeX.zip"
 	,
 	{{
 		"SyntaxAnnotations",

--- a/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
@@ -92,6 +92,13 @@ Test[
 	,
 	TestID -> "SubscriptBox: nested"
 ]
+Test[
+	SubscriptBox["x", "y", BaseStyle -> {}] // tmpBoxesToString
+	,
+	"\\mmaSub{x}{y}"
+	,
+	TestID -> "SubscriptBox: with option"
+]
 
 Test[
 	SuperscriptBox["\[Pi]", "\[Pi]"] // tmpBoxesToString
@@ -107,6 +114,15 @@ Test[
 	"\\mmaSup{\\mmaSup{a}{b}}{\\mmaSup{c}{d}}"
 	,
 	TestID -> "SuperscriptBox: nested"
+]
+Test[
+	SuperscriptBox["a", "y",
+		DefaultBaseStyle -> {}, MultilineFunction -> Automatic
+	] // tmpBoxesToString
+	,
+	"\\mmaSup{a}{y}"
+	,
+	TestID -> "SuperscriptBox: with options"
 ]
 
 Test[
@@ -128,6 +144,14 @@ Test[
 	,
 	TestID -> "SubsuperscriptBox: nested"
 ]
+Test[
+	SubsuperscriptBox["a", "1", "2", MultilineFunction -> None] //
+		tmpBoxesToString
+	,
+	"\\mmaSubSup{a}{1}{2}"
+	,
+	TestID -> "SubsuperscriptBox: with option"
+]
 
 Test[
 	UnderscriptBox["\[Pi]", "\[Pi]"] // tmpBoxesToString
@@ -144,6 +168,15 @@ Test[
 	,
 	TestID -> "UnderscriptBox: nested"
 ]
+Test[
+	UnderscriptBox["\[Alpha]", "\[Beta]",
+		DiacriticalPositioning -> Automatic, LimitsPositioning -> Automatic
+	] // tmpBoxesToString
+	,
+	"\\mmaUnder{\\alpha}{\\(\\beta\\)}"
+	,
+	TestID -> "UnderscriptBox: math mode, with options"
+]
 
 Test[
 	OverscriptBox["\[Pi]", "\[Pi]"] // tmpBoxesToString
@@ -159,6 +192,14 @@ Test[
 	"\\mmaOver{\\mmaOver{a}{b}}{\\mmaOver{c}{d}}"
 	,
 	TestID -> "OverscriptBox: nested"
+]
+Test[
+	OverscriptBox["a", "\[Gamma]", MultilineFunction -> Automatic] //
+		tmpBoxesToString
+	,
+	"\\mmaOver{a}{\\(\\gamma\\)}"
+	,
+	TestID -> "OverscriptBox: partial math mode, with option"
 ]
 
 Test[
@@ -180,6 +221,14 @@ Test[
 	,
 	TestID -> "UnderoverscriptBox: nested"
 ]
+Test[
+	UnderoverscriptBox["\[Delta]", "x", "\[Pi]", BaseStyle -> {}] //
+		tmpBoxesToString
+	,
+	"\\mmaUnderOver{\\delta}{x}{\\(\\pi\\)}"
+	,
+	TestID -> "UnderoverscriptBox: partial math mode, with option"
+]
 
 Test[
 	FractionBox["\[Pi]", "\[Pi]"] // tmpBoxesToString
@@ -196,6 +245,16 @@ Test[
 	,
 	TestID -> "FractionBox: nested"
 ]
+Test[
+	FractionBox["\[Epsilon]", "z",
+		DenominatorAlignment -> Center, FractionLine -> Automatic,
+		MultilineFunction -> Automatic, NumeratorAlignment -> Center
+	] // tmpBoxesToString
+	,
+	"\\mmaFrac{\\(\\epsilon\\)}{z}"
+	,
+	TestID -> "FractionBox: partial math mode, with options"
+]
 
 Test[
 	SqrtBox["\[Pi]"] // tmpBoxesToString
@@ -210,6 +269,13 @@ Test[
 	"\\mmaSqrt{\\mmaSqrt{a}}"
 	,
 	TestID -> "SqrtBox: nested"
+]
+Test[
+	SqrtBox["x", SurdForm -> False] // tmpBoxesToString
+	,
+	"\\mmaSqrt{x}"
+	,
+	TestID -> "SqrtBox: with option"
 ]
 
 Test[
@@ -226,6 +292,14 @@ Test[
 	"\\mmaRadical{\\mmaRadical{a}{b}}{\\mmaRadical{c}{d}}"
 	,
 	TestID -> "RadicalBox: nested"
+]
+Test[
+	RadicalBox["x", "\[Zeta]", ExponentPosition -> {0.2, 0.1}] //
+		tmpBoxesToString
+	,
+	"\\mmaRadical{x}{\\(\\zeta\\)}"
+	,
+	TestID -> "RadicalBox: partial math mode, with option"
 ]
 
 If[$VersionNumber >= 10,

--- a/CellsToTeX/Tests/Unit/headRulesToBoxRules.mt
+++ b/CellsToTeX/Tests/Unit/headRulesToBoxRules.mt
@@ -21,45 +21,61 @@ $ContextPath =
 
 Block[{$commandCharsToTeX = {"%" -> "%%", "<" -> "%<", ">" -> "%>"}},
 	TestMatch[
-		{FractionBox -> "frac"} // headRulesToBoxRules
+		FractionBox -> "frac" // headRulesToBoxRules
 		,
-		{
-			FractionBox[Verbatim[Pattern][name_, Verbatim[___]]] :>
-				"%frac" <> ("<" <> makeString[#] <> ">"& /@ {name_})
-		}
+		Verbatim[HoldPattern] @ FractionBox[
+			Verbatim[Pattern][pattName_, Verbatim[___]],
+			Verbatim[OptionsPattern[]]
+		] :>
+			"%frac" <> ("<" <> makeString[#] <> ">"& /@ {pattName_})
 		,
-		TestID -> "1 rule"
-	];
+		TestID -> "Single rule"
+	]
+]
 	
+Block[{$commandCharsToTeX = {"A" -> "B", "C" -> "D", "E" -> "F"}},
 	TestMatch[
-		{myBox -> {"myCommand", {{1}, {3}}}} // headRulesToBoxRules
+		myBox -> {"myCommand", {{1}, {3}}} // headRulesToBoxRules
 		,
-		{
-			myBox[Verbatim[Pattern][name_, Verbatim[___]]] :>
-				"%myCommand" <> (
-					"<" <> # <> ">"& /@ MapAt[
-						removeMathMode,
-						makeString /@ {name_},
-						{{1}, {3}}
-					]
-				)
-		}
+		Verbatim[HoldPattern] @ myBox[
+			Verbatim[Pattern][pattName_, Verbatim[___]],
+			Verbatim[OptionsPattern[]]
+		] :>
+			"AmyCommand" <> (
+				"C" <> # <> "E"& /@ MapAt[
+					removeMathMode,
+					makeString /@ {pattName_},
+					{{1}, {3}}
+				]
+			)
 		,
-		TestID -> "1 rule: with math mode args positions"
-	];
+		TestID -> "Single rule: with math mode args positions"
+	]
+]
 	
+Block[{$commandCharsToTeX = {"|" -> "x", "(" -> "y", ")" -> "z"}},
 	TestMatch[
-		{SubscriptBox -> "sub", SuperscriptBox -> "sup"} //
+		{SubscriptBox -> {"sub", 1}, UnderoverscriptBox -> "uo"} //
 			headRulesToBoxRules
 		,
 		{
-			SubscriptBox[Verbatim[Pattern][name_, Verbatim[___]]] :>
-				"%sub" <> ("<" <> makeString[#] <> ">"& /@ {name_}),
-			SuperscriptBox[Verbatim[Pattern][name_, Verbatim[___]]] :>
-				"%sup" <> ("<" <> makeString[#] <> ">"& /@ {name_})
+			Verbatim[HoldPattern] @ SubscriptBox[
+				Verbatim[Pattern][pattName1_, Verbatim[___]],
+				Verbatim[OptionsPattern[]]
+			] :>
+				"|sub" <> (
+					"(" <> # <> ")"& /@
+						MapAt[removeMathMode, makeString /@ {pattName1_}, 1]
+				)
+			,
+			Verbatim[HoldPattern] @ UnderoverscriptBox[
+				Verbatim[Pattern][pattName2_, Verbatim[___]],
+				Verbatim[OptionsPattern[]]
+			] :>
+				"|uo" <> ("(" <> makeString[#] <> ")"& /@ {pattName2_})
 		}
 		,
-		TestID -> "2 rules"
+		TestID -> "List of rules"
 	]
 ]
 

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,10 +1,10 @@
 (* Paclet Info File *)
 
-(* created 2015/11/03*)
+(* created 2016/01/30*)
 
 Paclet[
     Name -> "CellsToTeX",
-    Version -> "0.1.3",
+    Version -> "0.1.4",
     MathematicaVersion -> "6+",
     Description -> "Convert Mathematica cells to TeX, retaining formatting",
     Creator -> "Jakub Kuczmarski",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To load CellsToTeX package evaluate: ``Needs["CellsToTeX`"]``.
 ### Manual installation
 
 1. Download latest released
-   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.3/CellsToTeX.zip)
+   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.4/CellsToTeX.zip)
    file.
 
 2. Extract downloaded `CellsToTeX.zip` to any directory which is on


### PR DESCRIPTION
Before this fix, conversion of "formatting" boxes like `SuperscriptBox` was converting all box arguments including options, which lead to errors, since options are not supported boxes.

Now those options are ignored.

Fixes #7.