### PR TITLE
Non-ASCII symbols annotations

### DIFF
--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -58,7 +58,7 @@ $cellStyleOptions \
 is a List of rules with left hand sides being Lists of two elements. First \
 element is a pattern matching particular cell styles, second element is \
 option name. Right hand sides of rules are default values of options that \
-will be used for styles mathcing said pattern."
+will be used for styles matching said pattern."
 
 
 $commandCharsToTeX::usage =

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -447,6 +447,13 @@ headRulesToBoxRules[{rule1, rule2, ...}] \
 returns List of transformed rules."
 
 
+defaultOrFirst::usage =
+"\
+defaultOrFirst[list, default] \
+returns default if it's member of given list, otherwise first element of list \
+is returned. Given list should have at least one element."
+
+
 commonestAnnotationTypes::usage =
 "\
 commonestAnnotationTypes[boxes] \
@@ -1251,6 +1258,15 @@ headRulesToBoxRules[
 		HoldPattern @ boxHead[boxes:Repeated[_, {argsNo}], OptionsPattern[]] :>
 			comm <> (argStart <> makeString[#] <> argEnd& /@ {boxes})
 	]
+
+
+(* ::Subsubsection:: *)
+(*defaultOrFirst*)
+
+
+defaultOrFirst[{___, default_, ___}, default_] := default
+
+defaultOrFirst[{first_, ___}, _] := first
 
 
 (* ::Subsubsection:: *)

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1843,10 +1843,13 @@ getBoxesToFormattedTeX[OptionsPattern[]] :=
 			(* else *),
 				{
 					str_String :>
-						StringJoin @ Replace[
-							Characters[makeStringDefault[str]],
-							characterRules,
-							{1}
+						StringReplace[
+							StringJoin @ Replace[
+								Characters[makeStringDefault[str]],
+								characterRules,
+								{1}
+							],
+							"\\)\\(" -> ""
 						]
 				}
 			]

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -79,6 +79,52 @@ UsingFrontEnd @ Test[
 ]
 
 
+Block[{\[Phi]1},
+	\[Phi]1[x_] := x;
+	
+	Test[
+		CellToTeX[
+			Sum[
+				\[Phi]1[\[Alpha]]^2 + \[Chi]\[Omega]\[Nu]\[Sigma]\[Tau],
+				{\[Alpha], 1, \[Pi]}
+			] // MakeBoxes
+			,
+			"Style" -> "Input"
+		]
+		,
+		"\
+\\begin{mmaCell}{Input}
+  \\mmaUnderOver{\\(\\sum\\)}{\\mmaFnc{\\(\\alpha\\)}=1}{\\(\\pi\\)}(\\mmaSup{\\mmaDef{\\(\\phi\\)1}[\\mmaFnc{\\(\\alpha\\)}]}{2}+\\mmaUnd{\\(\\chi\\omega\\nu\\sigma\\tau\\)})
+\\end{mmaCell}"
+		,
+		TestID -> "pure boxes: formatting, syntax, non-ASCII symbols: Input"
+	]
+]
+
+
+Block[{\[Phi]1},
+	\[Phi]1[x_] := x;
+	
+	UsingFrontEnd @ Test[
+		CellToTeX[
+			Sum[
+				\[Phi]1[\[Alpha]]^2 + \[Chi]\[Omega]\[Nu]\[Sigma]\[Tau],
+				{\[Alpha], 1, \[Pi]}
+			] // MakeBoxes
+			,
+			"Style" -> "Code"
+		]
+		,
+		"\
+\\begin{mmaCell}{Code}
+  Sum[\\mmaDef{\\[Phi]1}[\\mmaFnc{\\[Alpha]}]^2 + \\mmaUnd{\\[Chi]\\[Omega]\\[Nu]\\[Sigma]\\[Tau]}, {\\mmaFnc{\\[Alpha]}, 1, Pi}]
+\\end{mmaCell}"
+		,
+		TestID -> "pure boxes: formatting, syntax, non-ASCII symbols: Code"
+	]
+]
+
+
 Test[
 	CellToTeX[
 		BoxData @ RowBox[{
@@ -174,9 +220,9 @@ UsingFrontEnd @ Test[
 	]
 	,
 	"\
-\\begin{mmaCell}[addtoindex=3,morelocal={x, x_}]{Code}
-  Solve[a*\\mmaFnc{x} + c == 0, \\mmaFnc{x}]; 
-  Module[{x, \\mmaLoc{a}}, x_ = x \\[PlusMinus] 1]
+\\begin{mmaCell}[addtoindex=3,morefunctionlocal={x},morelocal={x_}]{Code}
+  Solve[a*x + c == 0, x]; 
+  Module[{\\mmaLoc{x}, \\mmaLoc{a}}, x_ = \\mmaLoc{x} \\[PlusMinus] 1]
 \\end{mmaCell}"
 	,
 	TestID -> "Code cell: no formatting, different syntax roles, index"

--- a/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
+++ b/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
@@ -227,7 +227,7 @@ With[
 
 
 (* ::Subsection:: *)
-(*Complex*)
+(*CommonestTypesAsTeXOptions option*)
 
 
 With[
@@ -235,7 +235,8 @@ With[
 		data = {
 			"Boxes" -> MakeBoxes[f[x_] := x y],
 			"BoxRules" -> {},
-			"TeXOptions" -> {}
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> True
 		}
 	},
 	Test[
@@ -244,11 +245,162 @@ With[
 		{
 			"Boxes" -> MakeBoxes[f[x_] := x y],
 			"BoxRules" -> {$syntaxBoxToTeXSeq},
-			"TeXOptions" -> {"morepattern" -> {"x", "x_"}},
+			"TeXOptions" -> {"morepattern" -> {"x_", "x"}},
 			data
 		}
 		,
-		TestID -> "2 symbols + pattern: function delayed definition"
+		TestID -> "CommonestTypesAsTeXOptions -> True: ASCII symbols"
+	]
+]
+With[
+	{
+		data = {
+			"Boxes" ->
+				MakeBoxes[\[Phi][\[Epsilon]_] := \[Epsilon] \[Epsilon]0],
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> True
+		}
+	},
+	Test[
+		data // annotateSyntaxProcessor
+		,
+		{
+			"Boxes" ->
+				MakeBoxes[\[Phi][\[Epsilon]_] := \[Epsilon] \[Epsilon]0],
+			"BoxRules" -> {$syntaxBoxToTeXSeq},
+			"TeXOptions" -> {"morepattern" -> {"\[Epsilon]_", "\[Epsilon]"}},
+			data
+		}
+		,
+		TestID -> "CommonestTypesAsTeXOptions -> True: non-ASCII symbols"
+	]
+]
+
+
+With[
+	{
+		data = {
+			"Boxes" -> MakeBoxes[f[x_] := x y],
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> "ASCII"
+		}
+	},
+	Test[
+		data // annotateSyntaxProcessor
+		,
+		{
+			"Boxes" -> MakeBoxes[f[x_] := x y],
+			"BoxRules" -> {$syntaxBoxToTeXSeq},
+			"TeXOptions" -> {"morepattern" -> {"x_", "x"}},
+			data
+		}
+		,
+		TestID -> "CommonestTypesAsTeXOptions -> ASCII: ASCII symbols"
+	]
+]
+With[
+	{
+		data = {
+			"Boxes" ->
+				MakeBoxes[\[Phi][\[Epsilon]_] := \[Epsilon] \[Epsilon]0],
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> "ASCII"
+		}
+	},
+	Test[
+		data // annotateSyntaxProcessor
+		,
+		{
+			"Boxes" ->
+				RowBox[{
+					RowBox[{SyntaxBox["\[Phi]", "UndefinedSymbol"], "[",
+						SyntaxBox["\[Epsilon]_", "PatternVariable"],
+					"]"}],
+					":=",
+					RowBox[{
+						SyntaxBox["\[Epsilon]", "PatternVariable"],
+						" ",
+						SyntaxBox["\[Epsilon]0", "UndefinedSymbol"]
+					}]
+				}],
+			"BoxRules" -> {$syntaxBoxToTeXSeq},
+			"TeXOptions" -> {},
+			data
+		}
+		,
+		TestID -> "CommonestTypesAsTeXOptions -> ASCII: non-ASCII symbols"
+	]
+]
+
+
+With[
+	{
+		data = {
+			"Boxes" -> MakeBoxes[f[x_] := x y],
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> False
+		}
+	},
+	Test[
+		data // annotateSyntaxProcessor
+		,
+		{
+			"Boxes" ->
+				RowBox[{
+					RowBox[{SyntaxBox["f", "UndefinedSymbol"], "[",
+						SyntaxBox["x_", "PatternVariable"],
+					"]"}],
+					":=",
+					RowBox[{
+						SyntaxBox["x", "PatternVariable"],
+						" ",
+						SyntaxBox["y", "UndefinedSymbol"]
+					}]
+				}],
+			"BoxRules" -> {$syntaxBoxToTeXSeq},
+			"TeXOptions" -> {},
+			data
+		}
+		,
+		TestID -> "CommonestTypesAsTeXOptions -> False: ASCII symbols"
+	]
+]
+With[
+	{
+		data = {
+			"Boxes" ->
+				MakeBoxes[\[Phi][\[Epsilon]_] := \[Epsilon] \[Epsilon]0],
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> False
+		}
+	},
+	Test[
+		data // annotateSyntaxProcessor
+		,
+		{
+			"Boxes" ->
+				RowBox[{
+					RowBox[{SyntaxBox["\[Phi]", "UndefinedSymbol"], "[",
+						SyntaxBox["\[Epsilon]_", "PatternVariable"],
+					"]"}],
+					":=",
+					RowBox[{
+						SyntaxBox["\[Epsilon]", "PatternVariable"],
+						" ",
+						SyntaxBox["\[Epsilon]0", "UndefinedSymbol"]
+					}]
+				}],
+			"BoxRules" -> {$syntaxBoxToTeXSeq},
+			"TeXOptions" -> {},
+			data
+		}
+		,
+		TestID -> "CommonestTypesAsTeXOptions -> False: non-ASCII symbols"
 	]
 ]
 
@@ -396,7 +548,8 @@ Test[
 					HoldForm @ {"Boxes", "TeXOptions"},
 					HoldForm @ {
 						"BoxRules", "AnnotationTypesToTeX",
-						"AnnotationTypesNormalizer"
+						"AnnotationTypesNormalizer",
+						"CommonestTypesAsTeXOptions", "BoxesToAnnotationTypes"
 					}
 				}
 			]
@@ -449,6 +602,54 @@ With[
 			,
 			TestID -> "Exception: Unsupported AnnotationType"
 		]
+	]
+]
+
+
+With[
+	{
+		data = {
+			"Boxes" -> "testUndefinedSymbol",
+			"BoxRules" -> {},
+			"TeXOptions" -> {},
+			"CommonestTypesAsTeXOptions" -> "testUnsupportedOptVal"
+		}
+	},
+	Test[
+		Catch[
+			data // annotateSyntaxProcessor;
+			,
+			_
+			,
+			HoldComplete
+		]
+		,
+		HoldComplete @@ {
+			Failure[
+				CellsToTeXException[
+					"Unsupported", "OptionValue", "CommonestTypesAsTeXOptions"
+				],
+				Association[
+					"MessageTemplate" :> CellsToTeXException::unsupported,
+					"MessageParameters" -> {
+						HoldForm @ annotateSyntaxProcessor[data],
+						HoldForm @ CellsToTeXException[
+							"Unsupported", "OptionValue",
+							"CommonestTypesAsTeXOptions"
+						],
+						HoldForm @ "OptionValue",
+						HoldForm @ "testUnsupportedOptVal",
+						HoldForm @ {True, "ASCII", False}
+					}
+				]
+			],
+			CellsToTeXException[
+				"Unsupported", "OptionValue", "CommonestTypesAsTeXOptions"
+			]
+		}
+		,
+		TestID ->
+			"Exception: Unsupported OptionValue CommonestTypesAsTeXOptions"
 	]
 ]
 

--- a/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
@@ -68,6 +68,14 @@ Test[
 	TestID -> "}"
 ]
 
+Test[
+	"\[Alpha]\[Beta]\[Gamma]" // tmpBoxesToString
+	,
+	"\\(\\alpha\\beta\\gamma\\)"
+	,
+	TestID -> "\\[Alpha]\\[Beta]\\[Gamma]"
+]
+
 
 Test[
 	StyleBox[StyleBox["a", Red], Green] // tmpBoxesToString

--- a/CellsToTeX/Tests/Unit/commonestAnnotationTypes.mt
+++ b/CellsToTeX/Tests/Unit/commonestAnnotationTypes.mt
@@ -22,211 +22,320 @@ $ContextPath =
 	]
 
 
+SetAttributes[TestCommonestAnnotationTypes, HoldAllComplete]
+
+TestCommonestAnnotationTypes[
+	boxes_,
+	expected_,
+	Shortest[messages_:{}],
+	opts:OptionsPattern[Test]
+] := (
+	Test[
+		commonestAnnotationTypes[boxes, False]
+		,
+		expected
+		,
+		messages
+		,
+		opts
+		,
+		TestFailureMessage -> "False"
+	];
+	Test[
+		commonestAnnotationTypes[boxes, True]
+		,
+		expected
+		,
+		messages
+		,
+		opts
+		,
+		TestFailureMessage -> "True"
+	]
+)
+
+TestCommonestAnnotationTypes[args___] :=
+	With[{msg = "Incorrect arguments: " <> ToString[Unevaluated[{args}]]},
+		MUnit`Package`testError[msg, {}, args]
+	]
+
+
 (* ::Section:: *)
 (*Tests*)
+
+
+(* ::Subection:: *)
+(*ASCII*)
 
 
 Block[{defaultAnnotationType},
 	defaultAnnotationType["a"] = "testDefaultAnnotationTypeOfa";
 	defaultAnnotationType["b"] = "testDefaultAnnotationTypeOfb";
 	
-	Test[
-		"a" // commonestAnnotationTypes
-		,
-		{"a" -> "DefinedSymbol"}
-		,
-		TestID -> "1 symbol: 1 time: no"
-	];
-	Test[
-		SyntaxBox["a", "testNonDefault"] // commonestAnnotationTypes
+	TestCommonestAnnotationTypes[
+		SyntaxBox["a", "testNonDefault"]
 		,
 		{"a" -> "testNonDefault"}
 		,
-		TestID -> "1 symbol: 1 time: non-default"
+		TestID -> "ASCII: 1 symbol: 1 time: non-default"
 	];
-	Test[
-		SyntaxBox["a", "testDefaultAnnotationTypeOfa"] //
-			commonestAnnotationTypes
+	TestCommonestAnnotationTypes[
+		SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 1 time: default"
+		TestID -> "ASCII: 1 symbol: 1 time: default"
 	];
-	Test[
-		SyntaxBox["a", "testNonDefault", "testDefaultAnnotationTypeOfa"] //
-			commonestAnnotationTypes
+	TestCommonestAnnotationTypes[
+		SyntaxBox["a", "testNonDefault", "testDefaultAnnotationTypeOfa"]
 		,
 		{"a" -> "testNonDefault"}
 		,
-		TestID -> "1 symbol: 1 time: non-default + default"
+		TestID -> "ASCII: 1 symbol: 1 time: non-default + default"
 	];
-	Test[
-		SyntaxBox["a", "testDefaultAnnotationTypeOfa", "testNonDefault"] //
-			commonestAnnotationTypes
+	TestCommonestAnnotationTypes[
+		SyntaxBox["a", "testDefaultAnnotationTypeOfa", "testNonDefault"]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 1 time: default + non-default"
+		TestID -> "ASCII: 1 symbol: 1 time: default + non-default"
 	];
 	
 	
-	Test[
-		RowBox[{"a", "a"}] // commonestAnnotationTypes
-		,
-		{"a" -> "DefinedSymbol"}
-		,
-		TestID -> "1 symbol: 2 times: 1 no"
-	];
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testNonDefault"],
 			SyntaxBox["a", "testNonDefault"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testNonDefault"}
 		,
-		TestID -> "1 symbol: 2 times: 1 non-default"
+		TestID -> "ASCII: 1 symbol: 2 times: 1 non-default"
 	];
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 2 times: 1 default"
+		TestID -> "ASCII: 1 symbol: 2 times: 1 default"
 	];
 	
-	Test[
-		RowBox[{"a", SyntaxBox["a", "testNonDefault"]}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "testNonDefault"}
-		,
-		TestID -> "1 symbol: 2 times: 1 no, 1 non-default"
-	];
-	Test[
-		RowBox[{SyntaxBox["a", "testNonDefault"], "a"}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "testNonDefault"}
-		,
-		TestID -> "1 symbol: 2 times: 1 non-default, 1 no"
-	];
-	
-	Test[
-		RowBox[{"a", SyntaxBox["a", "testDefaultAnnotationTypeOfa"]}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "testDefaultAnnotationTypeOfa"}
-		,
-		TestID -> "1 symbol: 2 times: 1 no, 1 default"
-	];
-	Test[
-		RowBox[{SyntaxBox["a", "testDefaultAnnotationTypeOfa"], "a"}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "testDefaultAnnotationTypeOfa"}
-		,
-		TestID -> "1 symbol: 2 times: 1 default, 1 no"
-	];
-	
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testNonDefault"],
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 2 times: 1 non-default, 1 default"
+		TestID -> "ASCII: 1 symbol: 2 times: 1 non-default, 1 default"
 	];
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
 			SyntaxBox["a", "testNonDefault"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 2 times: 1 default, 1 non-default"
+		TestID -> "ASCII: 1 symbol: 2 times: 1 default, 1 non-default"
 	];
 	
 	
-	Test[
-		RowBox[{"a", "a", SyntaxBox["a", "testNonDefault"]}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "DefinedSymbol"}
-		,
-		TestID -> "1 symbol: 3 times: 2 no, 1 non-default"
-	];
-	Test[
-		RowBox[{"a", "a", SyntaxBox["a", "testDefaultAnnotationTypeOfa"]}] //
-			commonestAnnotationTypes
-		,
-		{"a" -> "DefinedSymbol"}
-		,
-		TestID -> "1 symbol: 3 times: 2 no, 1 default"
-	];
-	
-	Test[
-		RowBox[{
-			SyntaxBox["a", "testNonDefault"],
-			SyntaxBox["a", "testNonDefault"],
-			"a"
-		}] // commonestAnnotationTypes
-		,
-		{"a" -> "testNonDefault"}
-		,
-		TestID -> "1 symbol: 3 times: 2 non-default, 1 no"
-	];
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testNonDefault"],
 			SyntaxBox["a", "testNonDefault"],
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testNonDefault"}
 		,
-		TestID -> "1 symbol: 3 times: 2 non-default, 1 default"
+		TestID -> "ASCII: 1 symbol: 3 times: 2 non-default, 1 default"
 	];
-	
-	Test[
-		RowBox[{
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			"a"
-		}] // commonestAnnotationTypes
-		,
-		{"a" -> "testDefaultAnnotationTypeOfa"}
-		,
-		TestID -> "1 symbol: 3 times: 2 default, 1 no"
-	];
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
 			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
 			SyntaxBox["a", "testNonDefault"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
-		TestID -> "1 symbol: 3 times: 2 default, 1 non-default"
+		TestID -> "ASCII: 1 symbol: 3 times: 2 default, 1 non-default"
 	];
 	
 	
-	Test[
+	TestCommonestAnnotationTypes[
 		RowBox[{
 			SyntaxBox["a", "testNonDefaulta"],
 			SyntaxBox["b", "testNonDefaultb"]
-		}] // commonestAnnotationTypes
+		}]
 		,
 		{"a" -> "testNonDefaulta", "b" -> "testNonDefaultb"}
 		,
-		TestID -> "2 symbols: 1 times: 1 non-default; 1 times: 1 non-default"
+		TestID ->
+			"ASCII: 2 symbols: 1 times: 1 non-default; 1 times: 1 non-default"
+	];
+	
+	TestCommonestAnnotationTypes[
+		RowBox[{
+			SyntaxBox["a", "testNonDefaulta"],
+			SyntaxBox["b", "testNonDefaultb2"],
+			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
+			RowBox[{
+				SyntaxBox["b", "testNonDefaultb1"],
+				SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				SyntaxBox["a", "testNonDefaulta"],
+				SyntaxBox["b", "testNonDefaultb2"],
+				SyntaxBox["b", "testNonDefaultb1"],
+				SyntaxBox["b", "testNonDefaultb1"]
+			}]
+		}]
+		,
+		{"a" -> "testDefaultAnnotationTypeOfa", "b" -> "testNonDefaultb1"}
+		,
+		TestID -> "ASCII: 2 symbols: \
+4 times: 2 non-default, 2 default; 5 times: 3 non-default1, 2 non-default2"
+	];
+]
+
+
+(* ::Subection:: *)
+(*Non-ASCII*)
+
+
+Block[{defaultAnnotationType},
+	defaultAnnotationType["\[Alpha]"] = "testDefaultAnnotationTypeOfAlpha";
+	defaultAnnotationType["xy\[Alpha]z2"] =
+		"testDefaultAnnotationTypeOfxyAlphaz2";
+	defaultAnnotationType["\[Beta]"] = "testDefaultAnnotationTypeOfBeta";
+	defaultAnnotationType["b"] = "testDefaultAnnotationTypeOfb";
+	
+	
+	Test[
+		commonestAnnotationTypes[
+			SyntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			False
+		]
+		,
+		{}
+		,
+		TestID -> "Non-ASCII: 1 symbol: 1 time: non-default mixed: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			SyntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			True
+		]
+		,
+		{"xy\[Alpha]z2" -> "testNonDefault"}
+		,
+		TestID -> "Non-ASCII: 1 symbol: 1 time: non-default mixed: True"
+	];
+	
+	
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				SyntaxBox["\[Alpha]", "testNonDefault"]
+			}]
+			,
+			False
+		]
+		,
+		{}
+		,
+		TestID ->
+			"Non-ASCII: 1 symbol: 3 times: 2 default, 1 non-default: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				SyntaxBox["\[Alpha]", "testNonDefault"]
+			}]
+			,
+			True
+		]
+		,
+		{"\[Alpha]" -> "testDefaultAnnotationTypeOfAlpha"}
+		,
+		TestID ->
+			"Non-ASCII: 1 symbol: 3 times: 2 default, 1 non-default: True"
+	];
+	
+	
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				SyntaxBox["\[Beta]", "testNonDefaultBeta"]
+			}]
+			,
+			False
+		]
+		,
+		{}
+		,
+		TestID -> "Non-ASCII: 2 symbols: \
+1 times: 1 non-default; 1 times: 1 non-default: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				SyntaxBox["\[Beta]", "testNonDefaultBeta"]
+			}]
+			,
+			True
+		]
+		,
+		{
+			"\[Alpha]" -> "testNonDefaultAlpha",
+			"\[Beta]" -> "testNonDefaultBeta"
+		}
+		,
+		TestID -> "Non-ASCII: 2 symbols: \
+1 times: 1 non-default; 1 times: 1 non-default: True"
+	];
+	
+	
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				SyntaxBox["b", "testNonDefaultb"]
+			}]
+			,
+			False
+		]
+		,
+		{"b" -> "testNonDefaultb"}
+		,
+		TestID -> "Non-ASCII: 2 symbols: \
+1 times: 1 non-default; 1 times: 1 non-default ASCII: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				SyntaxBox["b", "testNonDefaultb"]
+			}]
+			,
+			True
+		]
+		,
+		{"\[Alpha]" -> "testNonDefaultAlpha", "b" -> "testNonDefaultb"}
+		,
+		TestID -> "Non-ASCII: 2 symbols: \
+1 times: 1 non-default; 1 times: 1 non-default ASCII: True"
 	];
 ]
 

--- a/CellsToTeX/Tests/Unit/defaultOrFirst.mt
+++ b/CellsToTeX/Tests/Unit/defaultOrFirst.mt
@@ -1,0 +1,83 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["CellsToTeX`Tests`Unit`defaultOrFirst`", {"MUnit`"}]
+
+
+Get["CellsToTeX`"]
+
+Get["CellsToTeX`Tests`Utilities`"]
+
+PrependTo[$ContextPath, "CellsToTeX`Internal`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Module[{a, b, c},
+	Test[
+		defaultOrFirst[{a, b, c}, a]
+		,
+		a
+		,
+		TestID -> "Default first"
+	]
+]
+Module[{a, b, c, d},
+	Test[
+		defaultOrFirst[{a, b, c, d}, b]
+		,
+		b
+		,
+		TestID -> "Default inside"
+	]
+]
+Module[{a, b, c, d, e},
+	Test[
+		defaultOrFirst[{a, b, c, d, e}, e]
+		,
+		e
+		,
+		TestID -> "Default last"
+	]
+]
+Module[{a, b, c, d, e, f, g},
+	Test[
+		defaultOrFirst[{a, b, c, d, e, f}, g]
+		,
+		a
+		,
+		TestID -> "Default not in list"
+	]
+]
+
+
+(* ::Subsection:: *)
+(*Incorrect arguments*)
+
+
+Module[{testArg},
+	Test[
+		Catch[defaultOrFirst[{}, testArg];, _, HoldComplete]
+		,
+		expectedIncorrectArgsError[defaultOrFirst[{}, testArg]]
+		,
+		TestID -> "Incorrect arguments"
+	]
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/CellsToTeX/Tests/Unit/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Unit/getBoxesToFormattedTeX.mt
@@ -67,10 +67,13 @@ TestMatch[
 	,
 	{
 		Verbatim[Pattern][pattName_, Verbatim[_String]] :>
-			StringJoin @ Replace[
-				Characters[makeStringDefault[pattName_]],
-				{testChar -> testCharReplacement},
-				{1}
+			StringReplace[
+				StringJoin @ Replace[
+					Characters[makeStringDefault[pattName_]],
+					{testChar -> testCharReplacement},
+					{1}
+				],
+				"\\)\\(" -> ""
 			]
 	}
 	,

--- a/CellsToTeX/Tests/Unit/suite.mt
+++ b/CellsToTeX/Tests/Unit/suite.mt
@@ -13,6 +13,7 @@ TestSuite[{
 	"getBoxesToFormattedTeX.mt",
 	"charToTeX.mt",
 	"defaultAnnotationType.mt",
+	"defaultOrFirst.mt",
 	"commonestAnnotationTypes.mt",
 	"annotationTypesToKeyVal.mt",
 	"labelToCellData.mt",

--- a/CellsToTeX/Tests/suite.mt
+++ b/CellsToTeX/Tests/suite.mt
@@ -13,6 +13,7 @@ TestSuite[{
 	"Unit/getBoxesToFormattedTeX.mt",
 	"Unit/charToTeX.mt",
 	"Unit/defaultAnnotationType.mt",
+	"Unit/defaultOrFirst.mt",
 	"Unit/commonestAnnotationTypes.mt",
 	"Unit/annotationTypesToKeyVal.mt",
 	"Unit/labelToCellData.mt",


### PR DESCRIPTION
New features: `"CommonestTypesAsTeXOptions"` and `"BoxesToAnnotationTypes"` options added to `annotateSyntaxProcessor`.

Fixed bug: commonest syntax roles of symbols containing non-ASCII characters are no longer moved to TeX environments option.