### PR TITLE
Fix custom command chars

### DIFF
--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1882,7 +1882,14 @@ charToTeX[char_] :=
 				]
 		]
 		,
-		" " -> ""
+		With[{escChar = $commandCharsToTeX[[1, 1]]},
+			{
+				" " -> "",
+				"\\{" -> escChar <> "{", "{" -> $commandCharsToTeX[[2, 1]],
+				"\\}" -> escChar <> "}", "}" -> $commandCharsToTeX[[3, 1]],
+				"\\\\" -> "\\\\", "\\" -> escChar
+			}
+		]
 	]
 
 

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1689,13 +1689,14 @@ $boxesToFormattedTeX =
 		#1["\[Integral]", scr_, OptionsPattern[]] :>
 			With[
 				{
+					escChar = $commandCharsToTeX[[1, 1]],
 					argStart = $commandCharsToTeX[[2, 1]],
 					argEnd = $commandCharsToTeX[[3, 1]]
 				}
 				,
 				StringJoin[
-					$commandCharsToTeX[[1, 1]], #2,
-					argStart, "\\int", argEnd,
+					escChar, #2,
+					argStart, escChar, "int", argEnd,
 					argStart, makeString[scr], argEnd
 				]
 			]
@@ -1708,13 +1709,14 @@ AppendTo[$boxesToFormattedTeX,
 	SubsuperscriptBox["\[Integral]", sub_, sup_, OptionsPattern[]] :>
 		With[
 			{
+				escChar = $commandCharsToTeX[[1, 1]],
 				argStart = $commandCharsToTeX[[2, 1]],
 				argEnd = $commandCharsToTeX[[3, 1]]
 			}
 			,
 			StringJoin[
-				$commandCharsToTeX[[1, 1]], "mmaSubSupM",
-				argStart, "\\int", argEnd,
+				escChar, "mmaSubSupM",
+				argStart, escChar, "int", argEnd,
 				argStart, makeString[sub], argEnd,
 				argStart, makeString[sup], argEnd
 			]

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1340,9 +1340,16 @@ annotationRulesToBoxRules[rules:{_Rule...}] :=
 		rules
 		,
 		(type_ -> {_, command_}) :>
-			With[{start = "\\" <> command <> "{"},
+			With[
+				{
+					start =
+						$commandCharsToTeX[[1, 1]] <> command <>
+							$commandCharsToTeX[[2, 1]],
+					end = $commandCharsToTeX[[3, 1]]
+				}
+				,
 				SyntaxBox[boxes_, type, ___] :>
-					start <> makeString[boxes] <> "}"
+					start <> makeString[boxes] <> end
 			]
 		,
 		{1}

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1846,7 +1846,11 @@ getBoxesToFormattedTeX[OptionsPattern[]] :=
 								characterRules,
 								{1}
 							],
-							"\\)\\(" -> ""
+							StringJoin[
+								$commandCharsToTeX[[1, 1]], ")",
+								$commandCharsToTeX[[1, 1]], "("
+							] ->
+								""
 						]
 				}
 			]

--- a/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
@@ -11,8 +11,10 @@ BeginPackage[
 
 Get["CellsToTeX`"]
 
+PrependTo[$ContextPath, "CellsToTeX`Configuration`"]
 
-With[{boxRules = CellsToTeX`Configuration`getBoxesToFormattedTeX[]},
+
+With[{boxRules = getBoxesToFormattedTeX[]},
 	tmpBoxesToString =
 		CellsToTeX`Internal`boxesToString[
 			#, boxRules, FormatType -> InputForm
@@ -107,12 +109,14 @@ Test[
 	,
 	TestID -> "SubscriptBox: with option"
 ]
-Test[
-	SubscriptBox["\[Integral]", "a"] // tmpBoxesToString
-	,
-	"\\mmaSubM{\\int}{a}"
-	,
-	TestID -> "SubscriptBox: \\[Integral]"
+Block[{$commandCharsToTeX = {"!" -> "test1", "(" -> "test2", ")" -> "test3"}},
+	Test[
+		SubscriptBox["\[Integral]", "a"] // tmpBoxesToString
+		,
+		"!mmaSubM(!int)(a)"
+		,
+		TestID -> "SubscriptBox: \\[Integral]: command chars"
+	]
 ]
 
 Test[

--- a/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Integration/getBoxesToFormattedTeX.mt
@@ -70,12 +70,14 @@ Test[
 	TestID -> "}"
 ]
 
-Test[
-	"\[Alpha]\[Beta]\[Gamma]" // tmpBoxesToString
-	,
-	"\\(\\alpha\\beta\\gamma\\)"
-	,
-	TestID -> "\\[Alpha]\\[Beta]\\[Gamma]"
+Block[{$commandCharsToTeX = {"&" -> "test1", "[" -> "test2", "]" -> "test3"}},
+	Test[
+		"\[Alpha]\[Beta]\[Gamma]" // tmpBoxesToString
+		,
+		"&(&alpha&beta&gamma&)"
+		,
+		TestID -> "\\[Alpha]\\[Beta]\\[Gamma]"
+	]
 ]
 
 

--- a/CellsToTeX/Tests/Unit/annotationRulesToBoxRules.mt
+++ b/CellsToTeX/Tests/Unit/annotationRulesToBoxRules.mt
@@ -26,36 +26,40 @@ $ContextPath =
 (*Tests*)
 
 
-TestMatch[
-	{"type" -> {"key", "comand"}} // annotationRulesToBoxRules
-	,
-	{
-		SyntaxBox[
-			Verbatim[Pattern][boxes_, Verbatim[_]], "type", Verbatim[___]
-		] :>
-			"\\comand{" <> makeString[boxes_] <> "}"
-	}
-	,
-	TestID -> "1 rule"
+Block[{$commandCharsToTeX = {"%" -> "%%", "<" -> "%<", ">" -> "%>"}},
+	TestMatch[
+		{"type" -> {"key", "comand"}} // annotationRulesToBoxRules
+		,
+		{
+			SyntaxBox[
+				Verbatim[Pattern][boxes_, Verbatim[_]], "type", Verbatim[___]
+			] :>
+				"%comand<" <> makeString[boxes_] <> ">"
+		}
+		,
+		TestID -> "1 rule"
+	]
 ]
 
-TestMatch[
-	{"type1" -> {"key1", "comand1"}, "type2" -> {"key2", "comand2"}} //
-		annotationRulesToBoxRules
-	,
-	{
-		SyntaxBox[
-			Verbatim[Pattern][boxes_, Verbatim[_]], "type1", Verbatim[___]
-		] :>
-			"\\comand1{" <> makeString[boxes_] <> "}"
+Block[{$commandCharsToTeX = {"\\" -> "test1", "{" -> "test2", "}" -> "test3"}},
+	TestMatch[
+		{"type1" -> {"key1", "comand1"}, "type2" -> {"key2", "comand2"}} //
+			annotationRulesToBoxRules
 		,
-		SyntaxBox[
-			Verbatim[Pattern][boxes_, Verbatim[_]], "type2", Verbatim[___]
-		] :>
-			"\\comand2{" <> makeString[boxes_] <> "}"
-	}
-	,
-	TestID -> "2 rules"
+		{
+			SyntaxBox[
+				Verbatim[Pattern][boxes_, Verbatim[_]], "type1", Verbatim[___]
+			] :>
+				"\\comand1{" <> makeString[boxes_] <> "}"
+			,
+			SyntaxBox[
+				Verbatim[Pattern][boxes_, Verbatim[_]], "type2", Verbatim[___]
+			] :>
+				"\\comand2{" <> makeString[boxes_] <> "}"
+		}
+		,
+		TestID -> "2 rules"
+	]
 ]
 
 

--- a/CellsToTeX/Tests/Unit/charToTeX.mt
+++ b/CellsToTeX/Tests/Unit/charToTeX.mt
@@ -16,12 +16,14 @@ PrependTo[$ContextPath, "CellsToTeX`Configuration`"]
 (*Tests*)
 
 
-Test[
-	charToTeX["\[PlusMinus]"]
-	,
-	"\\(\\pm\\)"
-	,
-	TestID -> "\[PlusMinus]"
+Block[{$commandCharsToTeX = {"?" -> "test1", "[" -> "test2", "]" -> "test3"}},
+	Test[
+		charToTeX["\[PlusMinus]"]
+		,
+		"?(?pm?)"
+		,
+		TestID -> "\[PlusMinus]"
+	]
 ]
 
 

--- a/CellsToTeX/Tests/Unit/getBoxesToFormattedTeX.mt
+++ b/CellsToTeX/Tests/Unit/getBoxesToFormattedTeX.mt
@@ -73,7 +73,11 @@ TestMatch[
 					{testChar -> testCharReplacement},
 					{1}
 				],
-				"\\)\\(" -> ""
+				StringJoin[
+					$commandCharsToTeX[[1, 1]], ")",
+					$commandCharsToTeX[[1, 1]], "("
+				] ->
+					""
 			]
 	}
 	,


### PR DESCRIPTION
Use escape characters from `$commandCharsToTeX`, instead of hard coded `"\\"`, `"{` and `"}"`.