### PR TITLE
Split mmaCellProcessor

### DIFF
--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1680,10 +1680,8 @@ $cellStyleOptions = {
 			$boxesToFormattedTeX,
 			headRulesToBoxRules[$boxHeadsToTeXCommands]
 		],
-	{"Code", "StringRules"} -> {},
 	{"Input" | "Output" | "Print" | "Message", "StringRules"} :>
 		Join[$stringsToTeX, $commandCharsToTeX],
-	{"Code", "NonASCIIHandler"} -> Identity,
 	{"Input", "NonASCIIHandler"} -> (charToTeX[#, FontWeight -> Bold]&),
 	{"Output" | "Print" | "Message", "NonASCIIHandler"} ->
 		(charToTeX[#, FontWeight -> Plain]&),
@@ -1692,6 +1690,23 @@ $cellStyleOptions = {
 		"Unicode",
 	{"Code" | "Input", "FormatType"} -> InputForm,
 	{"Output" | "Print" | "Message", "FormatType"} -> OutputForm,
+	{"Input", "TeXCodeSimplifier"} ->
+		(mergeAdjacentTeXCommands[
+			$commandCharsToTeX[[1, 1]] <> "pmb",
+			$commandCharsToTeX[[2, 1]],
+			$commandCharsToTeX[[3, 1]],
+			mergeAdjacentTeXDelims[
+				$commandCharsToTeX[[1, 1]] <> "(",
+				$commandCharsToTeX[[1, 1]] <> ")",
+				#
+			]
+		]&),
+	{"Output" | "Print" | "Message", "TeXCodeSimplifier"} ->
+		(mergeAdjacentTeXDelims[
+			$commandCharsToTeX[[1, 1]] <> "(",
+			$commandCharsToTeX[[1, 1]] <> ")",
+			#
+		]&),
 	{"Code" | "Input" | "Output", "Indexed"} -> True,
 	{"Print" | "Message", "Indexed"} -> False,
 	{"Code" | "Input", "Intype"} -> True,

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -525,6 +525,22 @@ optionsToTeX[pre, {key1 -> val1, key2 :> val2, ...}, post] \
 wraps result with pre and post, if result is not empty."
 
 
+mergeAdjacentTeXDelims::usage =
+"\
+mergeAdjacentTeXDelims[startDelim, endDelim][texCode] \
+returns String with given texCode in which code fragments, delimited by \
+startDelim and endDelim, separated only by tabs or spaces, are merged \
+together."
+
+
+mergeAdjacentTeXCommands::usage =
+"\
+mergeAdjacentTeXCommands[cmd, argStart, argEnd][texCode] \
+returns String with given texCode in which occurences of commands cmd with \
+single arguments, separated only by tabs or spaces, are merged into one \
+command."
+
+
 templateBoxDisplayBoxes::usage =
 "\
 templateBoxDisplayBoxes[templateBox] \
@@ -1465,6 +1481,37 @@ optionsToTeX[
 	pre_String, keyval:{(Rule | RuleDelayed)[_String, _]...}, post_String
 ] :=
 	pre <> optionsToTeX[keyval] <> post
+
+
+(* ::Subsubsection:: *)
+(*mergeAdjacentTeXDelims*)
+
+
+mergeAdjacentTeXDelims[startDelim_String, endDelim_String, texCode_String] :=
+	StringReplace[texCode, {
+		c : Except[WordCharacter] ~~ endDelim <> startDelim :> c,
+		endDelim <> startDelim ~~ c : Except[WordCharacter] :> c,
+		endDelim ~~ ws : (" " | "\t") .. ~~ startDelim :> ws
+	}]
+
+
+(* ::Subsubsection:: *)
+(*mergeAdjacentTeXCommands*)
+
+
+mergeAdjacentTeXCommands[
+	cmd_String, argStart_String, argEnd_String, texCode_String
+] :=
+	StringReplace[texCode,
+		cmds : (
+			RegularExpression[
+				StringReplace[cmd, "\\" -> "\\\\"] <> "(?P<braces>" <>
+				argStart <> "(?:[^" <> argStart <> argEnd <>
+				"]|(?P>braces))*" <> argEnd <> ")"
+			] ~~ (" " | "\t") ...
+		) .. :>
+			mergeAdjacentTeXDelims[cmd <> argStart, argEnd, cmds]
+]
 
 
 (* ::Subsubsection:: *)

--- a/CellsToTeX/Tests/Integration/$cellStyleOptions.mt
+++ b/CellsToTeX/Tests/Integration/$cellStyleOptions.mt
@@ -26,9 +26,10 @@ Test[
 	{
 		"Processor" ->
 			Composition[
-				trackCellIndexProcessor, mmaCellProcessor,
-				annotateSyntaxProcessor, toInputFormProcessor,
-				cellLabelProcessor, extractCellOptionsProcessor
+				trackCellIndexProcessor, mmaCellProcessor, boxesToTeXProcessor,
+				boxRulesProcessor, annotateSyntaxProcessor,
+				toInputFormProcessor, cellLabelProcessor,
+				extractCellOptionsProcessor
 			],
 		"BoxRules" :> $linearBoxesToTeX,
 		"StringRules" -> {},
@@ -49,8 +50,8 @@ Test[
 	{
 		"Processor" ->
 			Composition[
-				trackCellIndexProcessor, mmaCellProcessor,
-				annotateSyntaxProcessor, cellLabelProcessor,
+				trackCellIndexProcessor, mmaCellProcessor, boxesToTeXProcessor,
+				boxRulesProcessor, annotateSyntaxProcessor, cellLabelProcessor,
 				extractCellOptionsProcessor
 			],
 		"BoxRules" :>
@@ -77,8 +78,9 @@ Test[
 	{
 		"Processor" ->
 			Composition[
-				trackCellIndexProcessor, mmaCellProcessor,
-				cellLabelProcessor, extractCellOptionsProcessor
+				trackCellIndexProcessor, mmaCellProcessor, boxesToTeXProcessor,
+				boxRulesProcessor, cellLabelProcessor,
+				extractCellOptionsProcessor
 			],
 		"BoxRules" :>
 			Join[
@@ -104,8 +106,9 @@ Test[
 	{
 		"Processor" ->
 			Composition[
-				trackCellIndexProcessor, mmaCellProcessor,
-				cellLabelProcessor, extractCellOptionsProcessor
+				trackCellIndexProcessor, mmaCellProcessor, boxesToTeXProcessor,
+				boxRulesProcessor, cellLabelProcessor,
+				extractCellOptionsProcessor
 			],
 		"BoxRules" :>
 			Join[
@@ -132,8 +135,8 @@ Test[
 	{
 		"Processor" ->
 			Composition[
-				trackCellIndexProcessor, mmaCellProcessor,
-				messageLinkProcessor, cellLabelProcessor,
+				trackCellIndexProcessor, mmaCellProcessor, boxesToTeXProcessor,
+				boxRulesProcessor, messageLinkProcessor, cellLabelProcessor,
 				extractCellOptionsProcessor
 			],
 		"BoxRules" :>

--- a/CellsToTeX/Tests/Integration/$cellStyleOptions.mt
+++ b/CellsToTeX/Tests/Integration/$cellStyleOptions.mt
@@ -32,8 +32,6 @@ Test[
 				extractCellOptionsProcessor
 			],
 		"BoxRules" :> $linearBoxesToTeX,
-		"StringRules" -> {},
-		"NonASCIIHandler" -> Identity,
 		"CharacterEncoding" -> "ASCII",
 		"FormatType" -> InputForm,
 		"Indexed" -> True,
@@ -64,6 +62,17 @@ Test[
 		"NonASCIIHandler" -> (charToTeX[#, FontWeight -> Bold]&),
 		"CharacterEncoding" -> "Unicode",
 		"FormatType" -> InputForm,
+		"TeXCodeSimplifier" ->
+			(CellsToTeX`Internal`mergeAdjacentTeXCommands[
+				$commandCharsToTeX[[1, 1]] <> "pmb",
+				$commandCharsToTeX[[2, 1]],
+				$commandCharsToTeX[[3, 1]],
+				CellsToTeX`Internal`mergeAdjacentTeXDelims[
+					$commandCharsToTeX[[1, 1]] <> "(",
+					$commandCharsToTeX[[1, 1]] <> ")",
+					#
+				]
+			]&),
 		"Indexed" -> True,
 		"Intype" -> True
 	}
@@ -92,6 +101,12 @@ Test[
 		"NonASCIIHandler" -> (charToTeX[#, FontWeight -> Plain]&),
 		"CharacterEncoding" -> "Unicode",
 		"FormatType" -> OutputForm,
+		"TeXCodeSimplifier" ->
+			(CellsToTeX`Internal`mergeAdjacentTeXDelims[
+				$commandCharsToTeX[[1, 1]] <> "(",
+				$commandCharsToTeX[[1, 1]] <> ")",
+				#
+			]&),
 		"Indexed" -> True,
 		"Intype" -> False
 	}
@@ -120,6 +135,12 @@ Test[
 		"NonASCIIHandler" -> (charToTeX[#, FontWeight -> Plain]&),
 		"CharacterEncoding" -> "Unicode",
 		"FormatType" -> OutputForm,
+		"TeXCodeSimplifier" ->
+			(CellsToTeX`Internal`mergeAdjacentTeXDelims[
+				$commandCharsToTeX[[1, 1]] <> "(",
+				$commandCharsToTeX[[1, 1]] <> ")",
+				#
+			]&),
 		"Indexed" -> False,
 		"Intype" -> False,
 		"CellLabel" -> None
@@ -149,6 +170,12 @@ Test[
 		"NonASCIIHandler" -> (charToTeX[#, FontWeight -> Plain]&),
 		"CharacterEncoding" -> "Unicode",
 		"FormatType" -> OutputForm,
+		"TeXCodeSimplifier" ->
+			(CellsToTeX`Internal`mergeAdjacentTeXDelims[
+				$commandCharsToTeX[[1, 1]] <> "(",
+				$commandCharsToTeX[[1, 1]] <> ")",
+				#
+			]&),
 		"Indexed" -> False,
 		"Intype" -> False,
 		"CellLabel" -> None

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -505,9 +505,10 @@ With[
 				HoldForm @ {
 					"Boxes", "Style", "Processor", "BoxRules", "StringRules",
 					"NonASCIIHandler", "CharacterEncoding", "FormatType",
-					"Indexed", "Intype", "CellLabel", "SupportedCellStyles",
-					"CellStyleOptions", "ProcessorOptions", "TeXOptions",
-					"CatchExceptions", "CurrentCellIndex", "PreviousIntype"
+					"TeXCodeSimplifier", "Indexed", "Intype", "CellLabel",
+					"SupportedCellStyles", "CellStyleOptions",
+					"ProcessorOptions", "TeXOptions", "CatchExceptions",
+					"CurrentCellIndex", "PreviousIntype"
 				}
 			]
 	}
@@ -548,9 +549,10 @@ With[
 				HoldForm @ {
 					"Boxes", "Style", "Processor", "BoxRules", "StringRules",
 					"NonASCIIHandler", "CharacterEncoding", "FormatType",
-					"Indexed", "Intype", "CellLabel", "SupportedCellStyles",
-					"CellStyleOptions", "ProcessorOptions", "TeXOptions",
-					"CatchExceptions", "CurrentCellIndex", "PreviousIntype"
+					"TeXCodeSimplifier", "Indexed", "Intype", "CellLabel",
+					"SupportedCellStyles", "CellStyleOptions",
+					"ProcessorOptions", "TeXOptions", "CatchExceptions",
+					"CurrentCellIndex", "PreviousIntype"
 				},
 				HoldForm @ Identity
 			]

--- a/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
+++ b/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
@@ -1,0 +1,211 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["CellsToTeX`Tests`Unit`boxRulesProcessor`", {"MUnit`"}]
+
+
+Get["CellsToTeX`"]
+
+Get["CellsToTeX`Tests`Utilities`"]
+
+PrependTo[$ContextPath, "CellsToTeX`Configuration`"]
+
+
+SetAttributes[withMockedFunctions, HoldFirst]
+
+withMockedFunctions[body_] :=
+	Block[
+		{
+			processorDataLookup, $processorDataLookupLog = {},
+			testLookedupBoxRule, testLookedupStringRules,
+			testLookedupStringRule, testLookedupNonASCIIHandler
+			,
+			testDefaultOptions,
+			testDefaultBoxRule, testDefaultStringRule,
+			testDefaultNonASCIIHandler
+			,
+			testData,
+			testBoxRule, testStringRule, testNonASCIIHandler,
+			testUnusedOptionName, testUnusedOptionValue
+		}
+		,
+		testLookedupStringRules = {testLookedupStringRule};
+		SetAttributes[processorDataLookup, HoldFirst];
+		mockFunction[
+			processorDataLookup,
+			$processorDataLookupLog,
+			{
+				{testLookedupBoxRule}, testLookedupStringRules,
+				testLookedupNonASCIIHandler
+			}
+		];
+		
+		testDefaultOptions = {
+			"BoxRules" -> {testDefaultBoxRule},
+			"StringRules" -> {testDefaultStringRule},
+			"NonASCIIHandler" -> testDefaultNonASCIIHandler
+		};
+		SetOptions[boxRulesProcessor, testDefaultOptions];
+		
+		testData = {
+			"BoxRules" -> {testBoxRule},
+			"StringRules" -> {testStringRule},
+			"NonASCIIHandler" -> testNonASCIIHandler,
+			testUnusedOptionName -> testUnusedOptionValue
+		};
+		
+		body
+	]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+withMockedFunctions@With[
+	{
+		newStringRules = {
+			testLookedupStringRule,
+			Verbatim[Pattern][
+				charPattName_, RegularExpression["[^[:ascii:]]"]
+			] :>
+				testLookedupNonASCIIHandler[charPattName_]
+		}
+	}
+	,
+	TestMatch[
+		boxRulesProcessor[testData]
+		,
+		{
+			"BoxRules" -> {
+				testLookedupBoxRule,
+				HoldPattern[
+					Verbatim[Pattern][strPattName_, Verbatim[Blank][String]] :>
+						StringReplace[
+							makeStringDefault[strPattName_], newStringRules
+						]
+				]
+			},
+			"StringRules" -> newStringRules,
+			testData
+		}
+		,
+		TestID -> "basic"
+	];
+	
+	Test[
+		$processorDataLookupLog
+		,
+		With[{testData = testData, testDefaultOptions = testDefaultOptions},
+			{HoldComplete[
+				boxRulesProcessor[testData],
+				{testData, testDefaultOptions},
+				{"BoxRules", "StringRules", "NonASCIIHandler"}
+			]}
+		]
+		,
+		TestID -> "passing data to processorDataLookup"
+	]
+]
+
+
+withMockedFunctions@With[
+	{
+		newStringRules = {
+			Verbatim[Pattern][
+				charPattName_, RegularExpression["[^[:ascii:]]"]
+			] :>
+				testLookedupNonASCIIHandler[charPattName_]
+		}
+	}
+	,
+	testLookedupStringRules = {};
+	
+	TestMatch[
+		boxRulesProcessor[testData]
+		,
+		{
+			"BoxRules" -> {
+				testLookedupBoxRule,
+				HoldPattern[
+					Verbatim[Pattern][strPattName_, Verbatim[Blank][String]] :>
+						StringReplace[
+							makeStringDefault[strPattName_], newStringRules
+						]
+				]
+			},
+			"StringRules" -> newStringRules,
+			testData
+		}
+		,
+		TestID -> "empty StringRules"
+	]
+]
+withMockedFunctions[
+	testLookedupNonASCIIHandler = Identity;
+	
+	TestMatch[
+		boxRulesProcessor[testData]
+		,
+		{
+			"BoxRules" -> {
+				testLookedupBoxRule,
+				HoldPattern[
+					Verbatim[Pattern][strPattName_, Verbatim[Blank][String]] :>
+						StringReplace[
+							makeStringDefault[strPattName_],
+							{testLookedupStringRule}
+						]
+				]
+			},
+			"StringRules" -> {testLookedupStringRule},
+			testData
+		}
+		,
+		TestID -> "Identity NonASCIIHandler"
+	]
+]
+withMockedFunctions[
+	testLookedupStringRules = {};
+	testLookedupNonASCIIHandler = Identity;
+	
+	TestMatch[
+		boxRulesProcessor[testData]
+		,
+		{
+			"BoxRules" -> {testLookedupBoxRule},
+			"StringRules" -> {},
+			testData
+		}
+		,
+		TestID -> "empty StringRules, Identity NonASCIIHandler"
+	]
+]
+
+
+(* ::Subsection:: *)
+(*Protected attribute*)
+
+
+Test[
+	MemberQ[Attributes[boxRulesProcessor], Protected]
+	,
+	True
+	,
+	TestID -> "Protected attribute"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/CellsToTeX/Tests/Unit/boxesToTeXProcessor.mt
+++ b/CellsToTeX/Tests/Unit/boxesToTeXProcessor.mt
@@ -1,0 +1,221 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["CellsToTeX`Tests`Unit`boxesToTeXProcessor`", {"MUnit`"}]
+
+
+Get["CellsToTeX`"]
+
+Get["CellsToTeX`Tests`Utilities`"]
+
+PrependTo[$ContextPath, "CellsToTeX`Configuration`"]
+
+
+SetAttributes[withMockedFunctions, HoldAll]
+
+withMockedFunctions[body_] :=
+	Block[
+		{
+			processorDataLookup, $processorDataLookupLog = {},
+			testLookedupBoxes, testLookedupBoxRuleLHS, testLookedupBoxRuleRHS
+			,
+			CellsToTeX`Internal`boxesToString, $boxesToStringLog = {},
+			testBoxesToStringResult
+			,
+			$commandCharsToTeX = $commandCharsToTeX
+			,
+			testDefaultBoxRules
+			,
+			testData, testToStringOptions,
+			testBoxes, testBoxRules, testFormatType, testCharacterEncoding,
+			testPageHeight, testUnusedOptionName, testUnusedOptionValue
+			,
+			$basicBoxes, testBasicBoxes,
+			testExtendedBoxRules
+		}
+		,
+		SetAttributes[processorDataLookup, HoldFirst];
+		mockFunction[
+			processorDataLookup,
+			$processorDataLookupLog,
+			{
+				testLookedupBoxes,
+				{testLookedupBoxRuleLHS -> testLookedupBoxRuleRHS}
+			}
+		];
+		
+		testBoxesToStringResult = "testBoxesToStringResult";
+		mockFunction[
+			CellsToTeX`Internal`boxesToString,
+			$boxesToStringLog,
+			testBoxesToStringResult
+		];
+		
+		SetOptions[boxesToTeXProcessor, {"BoxRules" -> testDefaultBoxRules}];
+		
+		testToStringOptions = {
+			"FormatType" -> testFormatType,
+			"CharacterEncoding" -> testCharacterEncoding,
+			"PageHeight" -> testPageHeight
+		};
+		testData =
+			Join[
+				{
+					"Boxes" -> testBoxes,
+					"BoxRules" -> testBoxRules,
+					testUnusedOptionName -> testUnusedOptionValue
+				},
+				testToStringOptions
+			];
+		
+		$basicBoxes = testBasicBoxes;
+		
+		testExtendedBoxRules = {
+			testLookedupBoxRuleLHS -> testLookedupBoxRuleRHS,
+			With[{testData = testData},
+				HoldPattern[
+					Verbatim[Pattern][
+						unsupBoxPattName_, Verbatim[Except][testBasicBoxes]
+					] :>
+						CellsToTeX`Internal`throwException[
+							boxesToTeXProcessor[testData],
+							{"Unsupported", "Box"},
+							{unsupBoxPattName_, {testLookedupBoxRuleLHS}}
+						]
+				]
+			]
+		};
+			
+		body
+	]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+withMockedFunctions[
+	Test[
+		boxesToTeXProcessor[testData]
+		,
+		{"TeXCode" -> testBoxesToStringResult, testData}
+		,
+		TestID -> "basic: returned value"
+	];
+	Test[
+		$processorDataLookupLog
+		,
+		With[{testData = testData},
+			{HoldComplete[
+				boxesToTeXProcessor[testData],
+				{testData, {"BoxRules" -> testDefaultBoxRules}},
+				{"Boxes", "BoxRules"}
+			]}
+		]
+		,
+		TestID -> "passing data to processorDataLookup"
+	];
+	TestMatch[
+		$boxesToStringLog
+		,
+		{HoldComplete @@ {
+			testLookedupBoxes, testExtendedBoxRules, testToStringOptions
+		}}
+		,
+		TestID -> "basic: boxesToString"
+	]
+]
+
+
+withMockedFunctions@Module[{testBoxDataContents},
+	testLookedupBoxes = BoxData[testBoxDataContents];
+	
+	Test[
+		boxesToTeXProcessor[testData]
+		,
+		{"TeXCode" -> testBoxesToStringResult, testData}
+		,
+		TestID -> "BoxData: returned value"
+	];
+	TestMatch[
+		$boxesToStringLog
+		,
+		{HoldComplete @@ {
+			testBoxDataContents, testExtendedBoxRules, testToStringOptions
+		}}
+		,
+		TestID -> "BoxData: boxesToString"
+	]
+]
+
+
+withMockedFunctions@Module[{testBoxDataContents, testCellstyle},
+	testLookedupBoxes = Cell[BoxData[testBoxDataContents], testCellstyle];
+	
+	Test[
+		boxesToTeXProcessor[testData]
+		,
+		{"TeXCode" -> testBoxesToStringResult, testData}
+		,
+		TestID -> "Cell: returned value"
+	];
+	TestMatch[
+		$boxesToStringLog
+		,
+		{HoldComplete @@ {
+			testBoxDataContents, testExtendedBoxRules, testToStringOptions
+		}}
+		,
+		TestID -> "Cell: boxesToString"
+	]
+]
+
+
+withMockedFunctions[
+	$commandCharsToTeX = {"$" -> "test1", ":" -> "test2", ";" -> "test3"};
+	testBoxesToStringResult = "\
+$($alpha$)$($beta$) $($gamma$)\t$($delta$) \t\t  \t$($epsilon$)
+$($zeta$)\[IndentingNewLine]$($eta$)\\(a\\)\\(b\\)";
+	
+	Test[
+		boxesToTeXProcessor[testData]
+		,
+		{
+			"TeXCode" ->"\
+$($alpha$beta $gamma\t$delta \t\t  \t$epsilon$)
+$($zeta$)\[IndentingNewLine]$($eta$)\\(a\\)\\(b\\)"
+			,
+			testData
+		}
+		,
+		TestID -> "adjacent math modes: returned value"
+	]
+]
+
+
+(* ::Subsection:: *)
+(*Protected attribute*)
+
+
+Test[
+	MemberQ[Attributes[boxesToTeXProcessor], Protected]
+	,
+	True
+	,
+	TestID -> "Protected attribute"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/CellsToTeX/Tests/Unit/mergeAdjacentTeXCommands.mt
+++ b/CellsToTeX/Tests/Unit/mergeAdjacentTeXCommands.mt
@@ -1,0 +1,63 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["CellsToTeX`Tests`Unit`mergeAdjacentTeXCommands`", {"MUnit`"}]
+
+
+Get["CellsToTeX`"]
+
+Get["CellsToTeX`Tests`Utilities`"]
+
+PrependTo[$ContextPath, "CellsToTeX`Internal`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	mergeAdjacentTeXCommands["\\pmb", "{", "}", "\
+a \\pmb{bcde}  \\pmb{fgh}	\\pmb{\\ijk}\\pmb{\\l{m}} \\pmb{n}\\pmb{op} qr\\pmb{st} \\pmb{uv}\[IndentingNewLine]
+\\pmb{wxy}z"
+	]
+	,
+	"\
+a \\pmb{bcde  fgh	\\ijk\\l{m} n}\\pmb{op} qr\\pmb{st uv}\[IndentingNewLine]
+\\pmb{wxy}z"
+	,
+	TestID -> "mixed"
+]
+
+
+(* ::Subsection:: *)
+(*Incorrect arguments*)
+
+
+Module[{testArg1, testArg2, testArg3, testArg4},
+	Test[
+		Catch[
+			mergeAdjacentTeXCommands[testArg1, testArg2, testArg3, testArg4];,
+			_,
+			HoldComplete
+		]
+		,
+		expectedIncorrectArgsError @
+			mergeAdjacentTeXCommands[testArg1, testArg2, testArg3, testArg4]
+		,
+		TestID -> "Incorrect arguments"
+	]
+]
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/CellsToTeX/Tests/Unit/mergeAdjacentTeXDelims.mt
+++ b/CellsToTeX/Tests/Unit/mergeAdjacentTeXDelims.mt
@@ -1,0 +1,63 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["CellsToTeX`Tests`Unit`mergeAdjacentTeXDelims`", {"MUnit`"}]
+
+
+Get["CellsToTeX`"]
+
+Get["CellsToTeX`Tests`Utilities`"]
+
+PrependTo[$ContextPath, "CellsToTeX`Internal`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	mergeAdjacentTeXDelims["\\(", "\\)", "\
+\\(\\a\\)\\(bcd\\) \t  \\(e\\)\\(\\fg\\)
+\\(hijk\\)"
+	]
+	,
+	"\
+\\(\\a\\)\\(bcd \t  e\\fg\\)
+\\(hijk\\)"
+	,
+	TestID -> "mixed"
+]
+
+
+(* ::Subsection:: *)
+(*Incorrect arguments*)
+
+
+Module[{testArg1, testArg2, testArg3},
+	Test[
+		Catch[
+			mergeAdjacentTeXDelims[testArg1, testArg2, testArg3];,
+			_,
+			HoldComplete
+		]
+		,
+		expectedIncorrectArgsError @
+			mergeAdjacentTeXDelims[testArg1, testArg2, testArg3]
+		,
+		TestID -> "Incorrect arguments"
+	]
+]
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/CellsToTeX/Tests/Unit/suite.mt
+++ b/CellsToTeX/Tests/Unit/suite.mt
@@ -26,6 +26,8 @@ TestSuite[{
 	"cellLabelProcessor.mt",
 	"trackCellIndexProcessor.mt",
 	"messageLinkProcessor.mt",
+	"boxRulesProcessor.mt",
+	"boxesToTeXProcessor.mt",
 	"mmaCellProcessor.mt",
 	"exportProcessor.mt",
 	"CellsToTeXException.mt",

--- a/CellsToTeX/Tests/Unit/suite.mt
+++ b/CellsToTeX/Tests/Unit/suite.mt
@@ -18,6 +18,8 @@ TestSuite[{
 	"labelToCellData.mt",
 	"optionValueToTeX.mt",
 	"optionsToTeX.mt",
+	"mergeAdjacentTeXDelims.mt",
+	"mergeAdjacentTeXCommands.mt",
 	"annotationRulesToBoxRules.mt",
 	"extractMessageLink.mt",
 	"prettifyPatterns.mt",

--- a/CellsToTeX/Tests/suite.mt
+++ b/CellsToTeX/Tests/suite.mt
@@ -26,6 +26,8 @@ TestSuite[{
 	"Unit/cellLabelProcessor.mt",
 	"Unit/trackCellIndexProcessor.mt",
 	"Unit/messageLinkProcessor.mt",
+	"Unit/boxRulesProcessor.mt",
+	"Unit/boxesToTeXProcessor.mt",
 	"Unit/mmaCellProcessor.mt",
 	"Unit/exportProcessor.mt",
 	"Unit/CellsToTeXException.mt",

--- a/CellsToTeX/Tests/suite.mt
+++ b/CellsToTeX/Tests/suite.mt
@@ -18,6 +18,8 @@ TestSuite[{
 	"Unit/labelToCellData.mt",
 	"Unit/optionValueToTeX.mt",
 	"Unit/optionsToTeX.mt",
+	"Unit/mergeAdjacentTeXDelims.mt",
+	"Unit/mergeAdjacentTeXCommands.mt",
 	"Unit/annotationRulesToBoxRules.mt",
 	"Unit/extractMessageLink.mt",
 	"Unit/prettifyPatterns.mt",


### PR DESCRIPTION
Backward incompatible change: split `mmaCellProcessor` to `boxRulesProcessor`, `boxesToTeXProcessor` and new `mmaCellProcessor`.