### PR TITLE
Adapt package to SyntaxAnnotations v0.2.0

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -9,7 +9,7 @@ BootstrapInstall[
 	,
 	{{
 		"SyntaxAnnotations",
-		"https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.1.3/SyntaxAnnotations.zip"
+		"https://github.com/jkuczm/MathematicaSyntaxAnnotations/releases/download/v0.2.0/SyntaxAnnotations.zip"
 	}}
 	,
 	"AdditionalFailureMessage" ->

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -35,7 +35,7 @@ Test[
 	,
 	"\
 \\begin{mmaCell}[morelst={morefvcmdparams=\\mathbbm 1},morefunctionlocal={y}]{Input}
-  \\mmaSubSupM{\\int}{r}{\\(\\pmb{\\infty}\\)}\\{\\mmaFrac{1}{\\mmaSup{y}{3} \\mmaSup{(1-\\mmaSup{(\\mmaFrac{a}{y})}{2})}{2}}\\}\\(\\mathbbm{d}\\)y
+  \\mmaSubSupM{\\int}{r}{\\mmaDef{\\(\\pmb{\\infty}\\)}}\\{\\mmaFrac{1}{\\mmaSup{y}{3} \\mmaSup{(1-\\mmaSup{(\\mmaFrac{a}{y})}{2})}{2}}\\}\\(\\mathbbm{d}\\)y
 \\end{mmaCell}"
 	,
 	TestID -> "pure boxes: formatting, syntax: Input"
@@ -73,7 +73,7 @@ Block[{\[Phi]1},
 		,
 		"\
 \\begin{mmaCell}{Input}
-  \\mmaUnderOver{\\(\\pmb{\\sum}\\)}{\\mmaFnc{\\(\\pmb{\\alpha}\\)}=1}{\\(\\pmb{\\pi}\\)}(\\mmaSup{\\mmaDef{\\(\\pmb{\\phi}\\)1}[\\mmaFnc{\\(\\pmb{\\alpha}\\)}]}{2}+\\mmaUnd{\\(\\pmb{\\chi\\omega\\nu\\sigma\\tau}\\)})
+  \\mmaUnderOver{\\(\\pmb{\\sum}\\)}{\\mmaFnc{\\(\\pmb{\\alpha}\\)}=1}{\\mmaDef{\\(\\pmb{\\pi}\\)}}(\\mmaSup{\\mmaDef{\\(\\pmb{\\phi}\\)1}[\\mmaFnc{\\(\\pmb{\\alpha}\\)}]}{2}+\\mmaUnd{\\(\\pmb{\\chi\\omega\\nu\\sigma\\tau}\\)})
 \\end{mmaCell}"
 		,
 		TestID -> "pure boxes: formatting, syntax, non-ASCII symbols: Input"
@@ -142,6 +142,41 @@ Code, Unicode encoding, math replacements"
 		TestID -> "pure boxes: syntax, non-ASCII symbols (private Unicode): \
 Code, Unicode encoding, math replacements: texMathReplacement"
 	]
+]
+
+
+Test[
+	CellToTeX[
+		BoxData[{
+			RowBox[{RowBox[{"f", "::", "usage"}], "=", "\"\<f[] gives something\>\""}],
+			"\[IndentingNewLine]",
+			RowBox[{
+				RowBox[{"f", "[", "]"}], ":=",
+				RowBox[{"Module", "[",
+					RowBox[{"(*", " ",
+						RowBox[{"A", " ", RowBox[{"comment", "."}]}],
+					" ", "*)"}],
+					RowBox[{
+						RowBox[{"{", "x", "}"}], ",",
+						RowBox[{
+							"\"\<A string\>\"", "<>",
+							RowBox[{"ToString", "[", "x", "]"}]
+						}]
+					}],
+				"]"}]
+			}]
+		}]
+		,
+		"Style" -> "Input"
+	]
+	,
+	"\
+\\begin{mmaCell}[morelocal={x}]{Input}
+  f::\\mmaStr{usage}=\"f[] gives something\"
+  f[]:=Module[(* A comment. *)\\{x\\},\"A string\"<>ToString[x]]
+\\end{mmaCell}"
+	,
+	TestID -> "BoxData: comment, string, syntax: Input"
 ]
 
 

--- a/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
+++ b/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
@@ -24,7 +24,7 @@ $ContextPath =
 
 
 MakeBoxes[syntaxExpr[expr_, types___], StandardForm] ^:=
-	SyntaxBox[MakeBoxes[expr], types]
+	syntaxBox[MakeBoxes[expr], types]
 
 $syntaxBoxToTeXSeq =
 	Sequence @@ annotationRulesToBoxRules[$annotationTypesToTeX]
@@ -316,14 +316,14 @@ With[
 		{
 			"Boxes" ->
 				RowBox[{
-					RowBox[{SyntaxBox["\[Phi]", "UndefinedSymbol"], "[",
-						SyntaxBox["\[Epsilon]_", "PatternVariable"],
+					RowBox[{syntaxBox["\[Phi]", "UndefinedSymbol"], "[",
+						syntaxBox["\[Epsilon]_", "PatternVariable"],
 					"]"}],
 					":=",
 					RowBox[{
-						SyntaxBox["\[Epsilon]", "PatternVariable"],
+						syntaxBox["\[Epsilon]", "PatternVariable"],
 						" ",
-						SyntaxBox["\[Epsilon]0", "UndefinedSymbol"]
+						syntaxBox["\[Epsilon]0", "UndefinedSymbol"]
 					}]
 				}],
 			"BoxRules" -> {$syntaxBoxToTeXSeq},
@@ -351,14 +351,14 @@ With[
 		{
 			"Boxes" ->
 				RowBox[{
-					RowBox[{SyntaxBox["f", "UndefinedSymbol"], "[",
-						SyntaxBox["x_", "PatternVariable"],
+					RowBox[{syntaxBox["f", "UndefinedSymbol"], "[",
+						syntaxBox["x_", "PatternVariable"],
 					"]"}],
 					":=",
 					RowBox[{
-						SyntaxBox["x", "PatternVariable"],
+						syntaxBox["x", "PatternVariable"],
 						" ",
-						SyntaxBox["y", "UndefinedSymbol"]
+						syntaxBox["y", "UndefinedSymbol"]
 					}]
 				}],
 			"BoxRules" -> {$syntaxBoxToTeXSeq},
@@ -385,14 +385,14 @@ With[
 		{
 			"Boxes" ->
 				RowBox[{
-					RowBox[{SyntaxBox["\[Phi]", "UndefinedSymbol"], "[",
-						SyntaxBox["\[Epsilon]_", "PatternVariable"],
+					RowBox[{syntaxBox["\[Phi]", "UndefinedSymbol"], "[",
+						syntaxBox["\[Epsilon]_", "PatternVariable"],
 					"]"}],
 					":=",
 					RowBox[{
-						SyntaxBox["\[Epsilon]", "PatternVariable"],
+						syntaxBox["\[Epsilon]", "PatternVariable"],
 						" ",
-						SyntaxBox["\[Epsilon]0", "UndefinedSymbol"]
+						syntaxBox["\[Epsilon]0", "UndefinedSymbol"]
 					}]
 				}],
 			"BoxRules" -> {$syntaxBoxToTeXSeq},
@@ -548,8 +548,8 @@ Test[
 					HoldForm @ {"Boxes", "TeXOptions"},
 					HoldForm @ {
 						"BoxRules", "AnnotationTypesToTeX",
-						"AnnotationTypesNormalizer",
-						"CommonestTypesAsTeXOptions", "BoxesToAnnotationTypes"
+						"CommonestTypesAsTeXOptions", "StringBoxToTypes",
+						"AnnotateComments"
 					}
 				}
 			]

--- a/CellsToTeX/Tests/Integration/fullNotebooks.mt
+++ b/CellsToTeX/Tests/Integration/fullNotebooks.mt
@@ -174,8 +174,7 @@ Test[
 				cell : Cell[_, __] :>
 					CellToTeX[cell, "ProcessorOptions" -> {
 						"CommonestTypesAsTeXOptions" -> False,
-						"BoxesToAnnotationTypes" ->
-							SyntaxAnnotations`$BoxesToAnnotationTypes,
+						"StringBoxToTypes" -> {Automatic},
 						"NonASCIIHandler" -> Identity
 					}]
 				,

--- a/CellsToTeX/Tests/Unit/annotationRulesToBoxRules.mt
+++ b/CellsToTeX/Tests/Unit/annotationRulesToBoxRules.mt
@@ -31,7 +31,7 @@ Block[{$commandCharsToTeX = {"%" -> "%%", "<" -> "%<", ">" -> "%>"}},
 		{"type" -> {"key", "comand"}} // annotationRulesToBoxRules
 		,
 		{
-			SyntaxBox[
+			syntaxBox[
 				Verbatim[Pattern][boxes_, Verbatim[_]], "type", Verbatim[___]
 			] :>
 				"%comand<" <> makeString[boxes_] <> ">"
@@ -47,12 +47,12 @@ Block[{$commandCharsToTeX = {"\\" -> "test1", "{" -> "test2", "}" -> "test3"}},
 			annotationRulesToBoxRules
 		,
 		{
-			SyntaxBox[
+			syntaxBox[
 				Verbatim[Pattern][boxes_, Verbatim[_]], "type1", Verbatim[___]
 			] :>
 				"\\comand1{" <> makeString[boxes_] <> "}"
 			,
-			SyntaxBox[
+			syntaxBox[
 				Verbatim[Pattern][boxes_, Verbatim[_]], "type2", Verbatim[___]
 			] :>
 				"\\comand2{" <> makeString[boxes_] <> "}"

--- a/CellsToTeX/Tests/Unit/commonestAnnotationTypes.mt
+++ b/CellsToTeX/Tests/Unit/commonestAnnotationTypes.mt
@@ -25,13 +25,13 @@ $ContextPath =
 SetAttributes[TestCommonestAnnotationTypes, HoldAllComplete]
 
 TestCommonestAnnotationTypes[
-	boxes_,
+	{boxes_, allowedTypes_},
 	expected_,
 	Shortest[messages_:{}],
 	opts:OptionsPattern[Test]
 ] := (
 	Test[
-		commonestAnnotationTypes[boxes, False]
+		commonestAnnotationTypes[boxes, allowedTypes, False]
 		,
 		expected
 		,
@@ -42,7 +42,7 @@ TestCommonestAnnotationTypes[
 		TestFailureMessage -> "False"
 	];
 	Test[
-		commonestAnnotationTypes[boxes, True]
+		commonestAnnotationTypes[boxes, allowedTypes, True]
 		,
 		expected
 		,
@@ -73,28 +73,28 @@ Block[{defaultAnnotationType},
 	defaultAnnotationType["b"] = "testDefaultAnnotationTypeOfb";
 	
 	TestCommonestAnnotationTypes[
-		SyntaxBox["a", "testNonDefault"]
+		{syntaxBox["a", "testNonDefault"], _}
 		,
 		{"a" -> "testNonDefault"}
 		,
 		TestID -> "ASCII: 1 symbol: 1 time: non-default"
 	];
 	TestCommonestAnnotationTypes[
-		SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
+		{syntaxBox["a", "testDefaultAnnotationTypeOfa"], _}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
 		TestID -> "ASCII: 1 symbol: 1 time: default"
 	];
 	TestCommonestAnnotationTypes[
-		SyntaxBox["a", "testNonDefault", "testDefaultAnnotationTypeOfa"]
+		{syntaxBox["a", "testNonDefault", "testDefaultAnnotationTypeOfa"], _}
 		,
 		{"a" -> "testNonDefault"}
 		,
 		TestID -> "ASCII: 1 symbol: 1 time: non-default + default"
 	];
 	TestCommonestAnnotationTypes[
-		SyntaxBox["a", "testDefaultAnnotationTypeOfa", "testNonDefault"]
+		{syntaxBox["a", "testDefaultAnnotationTypeOfa", "testNonDefault"], _}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
@@ -103,20 +103,26 @@ Block[{defaultAnnotationType},
 	
 	
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testNonDefault"],
-			SyntaxBox["a", "testNonDefault"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testNonDefault"],
+				syntaxBox["a", "testNonDefault"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testNonDefault"}
 		,
 		TestID -> "ASCII: 1 symbol: 2 times: 1 non-default"
 	];
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
@@ -124,20 +130,26 @@ Block[{defaultAnnotationType},
 	];
 	
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testNonDefault"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testNonDefault"],
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
 		TestID -> "ASCII: 1 symbol: 2 times: 1 non-default, 1 default"
 	];
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			SyntaxBox["a", "testNonDefault"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				syntaxBox["a", "testNonDefault"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
@@ -146,22 +158,28 @@ Block[{defaultAnnotationType},
 	
 	
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testNonDefault"],
-			SyntaxBox["a", "testNonDefault"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testNonDefault"],
+				syntaxBox["a", "testNonDefault"],
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testNonDefault"}
 		,
 		TestID -> "ASCII: 1 symbol: 3 times: 2 non-default, 1 default"
 	];
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-			SyntaxBox["a", "testNonDefault"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				syntaxBox["a", "testNonDefault"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa"}
 		,
@@ -170,10 +188,13 @@ Block[{defaultAnnotationType},
 	
 	
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testNonDefaulta"],
-			SyntaxBox["b", "testNonDefaultb"]
-		}]
+		{
+			RowBox[{
+				syntaxBox["a", "testNonDefaulta"],
+				syntaxBox["b", "testNonDefaultb"]
+			}],
+			_
+		}
 		,
 		{"a" -> "testNonDefaulta", "b" -> "testNonDefaultb"}
 		,
@@ -182,25 +203,50 @@ Block[{defaultAnnotationType},
 	];
 	
 	TestCommonestAnnotationTypes[
-		RowBox[{
-			SyntaxBox["a", "testNonDefaulta"],
-			SyntaxBox["b", "testNonDefaultb2"],
-			SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
+		{
 			RowBox[{
-				SyntaxBox["b", "testNonDefaultb1"],
-				SyntaxBox["a", "testDefaultAnnotationTypeOfa"],
-				SyntaxBox["a", "testNonDefaulta"],
-				SyntaxBox["b", "testNonDefaultb2"],
-				SyntaxBox["b", "testNonDefaultb1"],
-				SyntaxBox["b", "testNonDefaultb1"]
-			}]
-		}]
+				syntaxBox["a", "testNonDefaulta"],
+				syntaxBox["b", "testNonDefaultb2"],
+				syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+				RowBox[{
+					syntaxBox["b", "testNonDefaultb1"],
+					syntaxBox["a", "testDefaultAnnotationTypeOfa"],
+					syntaxBox["a", "testNonDefaulta"],
+					syntaxBox["b", "testNonDefaultb2"],
+					syntaxBox["b", "testNonDefaultb1"],
+					syntaxBox["b", "testNonDefaultb1"]
+				}]
+			}],
+			_
+		}
 		,
 		{"a" -> "testDefaultAnnotationTypeOfa", "b" -> "testNonDefaultb1"}
 		,
 		TestID -> "ASCII: 2 symbols: \
 4 times: 2 non-default, 2 default; 5 times: 3 non-default1, 2 non-default2"
 	];
+	
+	TestCommonestAnnotationTypes[
+		{syntaxBox["a", "testNonAllowed"], "testAllowed"}
+		,
+		{}
+		,
+		TestID -> "ASCII: 1 symbol: 1 time: not allowed"
+	];
+	TestCommonestAnnotationTypes[
+		{
+			RowBox[{
+				syntaxBox["a", "testExcluded"],
+				syntaxBox["a", "testNonDefault"],
+				syntaxBox["a", "testExcluded"]
+			}],
+			Except["testExcluded"]
+		}
+		,
+		{"a" -> "testNonDefault"}
+		,
+		TestID -> "ASCII: 1 symbol: 3 times: 1 non-default, 2 not allowed"
+	]
 ]
 
 
@@ -218,7 +264,8 @@ Block[{defaultAnnotationType},
 	
 	Test[
 		commonestAnnotationTypes[
-			SyntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			syntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			_,
 			False
 		]
 		,
@@ -228,7 +275,8 @@ Block[{defaultAnnotationType},
 	];
 	Test[
 		commonestAnnotationTypes[
-			SyntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			syntaxBox["xy\[Alpha]z2", "testNonDefault"],
+			_,
 			True
 		]
 		,
@@ -241,11 +289,12 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
-				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
-				SyntaxBox["\[Alpha]", "testNonDefault"]
+				syntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				syntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				syntaxBox["\[Alpha]", "testNonDefault"]
 			}]
 			,
+			_,
 			False
 		]
 		,
@@ -257,11 +306,12 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
-				SyntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
-				SyntaxBox["\[Alpha]", "testNonDefault"]
+				syntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				syntaxBox["\[Alpha]", "testDefaultAnnotationTypeOfAlpha"],
+				syntaxBox["\[Alpha]", "testNonDefault"]
 			}]
 			,
+			_,
 			True
 		]
 		,
@@ -275,10 +325,11 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
-				SyntaxBox["\[Beta]", "testNonDefaultBeta"]
+				syntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				syntaxBox["\[Beta]", "testNonDefaultBeta"]
 			}]
 			,
+			_,
 			False
 		]
 		,
@@ -290,10 +341,11 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
-				SyntaxBox["\[Beta]", "testNonDefaultBeta"]
+				syntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				syntaxBox["\[Beta]", "testNonDefaultBeta"]
 			}]
 			,
+			_,
 			True
 		]
 		,
@@ -310,10 +362,11 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
-				SyntaxBox["b", "testNonDefaultb"]
+				syntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				syntaxBox["b", "testNonDefaultb"]
 			}]
 			,
+			_,
 			False
 		]
 		,
@@ -325,10 +378,11 @@ Block[{defaultAnnotationType},
 	Test[
 		commonestAnnotationTypes[
 			RowBox[{
-				SyntaxBox["\[Alpha]", "testNonDefaultAlpha"],
-				SyntaxBox["b", "testNonDefaultb"]
+				syntaxBox["\[Alpha]", "testNonDefaultAlpha"],
+				syntaxBox["b", "testNonDefaultb"]
 			}]
 			,
+			_,
 			True
 		]
 		,
@@ -337,6 +391,63 @@ Block[{defaultAnnotationType},
 		TestID -> "Non-ASCII: 2 symbols: \
 1 times: 1 non-default; 1 times: 1 non-default ASCII: True"
 	];
+	
+	
+	Test[
+		commonestAnnotationTypes[
+			syntaxBox["\[Alpha]", "testNonAllowed"],
+			"testAllowed",
+			False
+		]
+		,
+		{}
+		,
+		TestID -> "Non-ASCII: 1 symbol: 1 time: not allowed: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			syntaxBox["\[Alpha]", "testNonAllowed"],
+			"testAllowed",
+			True
+		]
+		,
+		{}
+		,
+		TestID -> "Non-ASCII: 1 symbol: 1 time: not allowed: True"
+	];
+	
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				syntaxBox["\[Alpha]", "testExcluded"],
+				syntaxBox["\[Alpha]", "testNonDefault"],
+				syntaxBox["\[Alpha]", "testExcluded"]
+			}],
+			Except["testExcluded"],
+			False
+		]
+		,
+		{}
+		,
+		TestID -> "Non-ASCII: 1 symbol: \
+3 times: 1 non-default, 2 not allowed: False"
+	];
+	Test[
+		commonestAnnotationTypes[
+			RowBox[{
+				syntaxBox["\[Alpha]", "testExcluded"],
+				syntaxBox["\[Alpha]", "testNonDefault"],
+				syntaxBox["\[Alpha]", "testExcluded"]
+			}],
+			Except["testExcluded"],
+			True
+		]
+		,
+		{"\[Alpha]" -> "testNonDefault"}
+		,
+		TestID -> "Non-ASCII: 1 symbol: \
+3 times: 1 non-default, 2 not allowed: True"
+	]
 ]
 
 
@@ -344,12 +455,16 @@ Block[{defaultAnnotationType},
 (*Incorrect arguments*)
 
 
-Module[{testArg1, testArg2},
+Module[{testArg1, testArg2, testArg3},
 	Test[
-		Catch[commonestAnnotationTypes[testArg1, testArg2];, _, HoldComplete]
+		Catch[
+			commonestAnnotationTypes[testArg1, testArg2, testArg3];,
+			_,
+			HoldComplete
+		]
 		,
 		expectedIncorrectArgsError @
-			commonestAnnotationTypes[testArg1, testArg2]
+			commonestAnnotationTypes[testArg1, testArg2, testArg3]
 		,
 		TestID -> "Incorrect arguments"
 	]

--- a/NoInstall.m
+++ b/NoInstall.m
@@ -1,6 +1,6 @@
 (* ::Package:: *)
 
 Block[{$ContextPath},
-	Import["https://raw.githubusercontent.com/jkuczm/MathematicaSyntaxAnnotations/v0.1.3/SyntaxAnnotations/SyntaxAnnotations.m"];
+	Import["https://raw.githubusercontent.com/jkuczm/MathematicaSyntaxAnnotations/v0.2.0/SyntaxAnnotations/SyntaxAnnotations.m"];
 ]
 Import["https://raw.githubusercontent.com/jkuczm/MathematicaCellsToTeX/master/CellsToTeX/CellsToTeX.m"]


### PR DESCRIPTION
Backward incompatible change: adapted `annotateSyntaxProcessor` options to new `AnnotateSyntax` options.

New feature: added `"String"` and `"Comment"` annotation types to `$annotationTypesToTeX` with only TeX annotation and no TeX keys.