### PR TITLE
Mma versions compatibility

### DIFF
--- a/BootstrapInstall.m
+++ b/BootstrapInstall.m
@@ -5,7 +5,7 @@ Get["https://raw.githubusercontent.com/jkuczm/MathematicaBootstrapInstaller/v0.1
 
 BootstrapInstall[
 	"CellsToTeX",
-	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.4/CellsToTeX.zip"
+	"https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.2.0/CellsToTeX.zip"
 	,
 	{{
 		"SyntaxAnnotations",

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -1320,7 +1320,7 @@ commonestAnnotationTypes[boxes_, allowedTypes_, specialChars : True|False] :=
 				name_String
 			(* else *),
 				name_String /;
-					StringMatchQ[name, RegularExpression["[[:ascii:]]*"]]
+					StringMatchQ[name, RegularExpression["[\\x00-\\x7F]*"]]
 			],
 			type:allowedTypes,
 			___
@@ -2368,7 +2368,7 @@ functionCall:boxRulesProcessor[data:{___?OptionQ}] :=
 		If[nonASCIIHandler =!= Identity,
 			With[{nonASCIIHandler = nonASCIIHandler},
 				AppendTo[stringRules,
-					char:RegularExpression["[^[:ascii:]]"] :>
+					char:RegularExpression["[^\\x00-\\x7F]"] :>
 						nonASCIIHandler[char]
 				]
 			]

--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -892,7 +892,8 @@ If[$VersionNumber < 10,
 		With[
 			{
 				msg = assoc["MessageTemplate"], 
-				msgParam = assoc["MessageParameters"]
+				msgParam = assoc["MessageParameters"], 
+				type = assoc["Type"]
 			}
 			, 
 			ToBoxes @ Interpretation[
@@ -901,18 +902,30 @@ If[$VersionNumber < 10,
 						{
 							Style["\[WarningSign]", "Message", FontSize -> 35]
 							,
-							"Message: " <> ToString[
+							Style["Message:", FontColor->GrayLevel[0.5]]
+							,
+							ToString[
 								StringForm[msg, Sequence @@ msgParam], 
 								StandardForm
 							]
 						},
-						{SpanFromAbove, "Tag:" <> ToString[tag, StandardForm]}
+						{
+							SpanFromAbove,
+							Style["Tag:", FontColor->GrayLevel[0.5]],
+							ToString[tag, StandardForm]
+						},
+						{
+							SpanFromAbove,
+							Style["Type:", FontColor->GrayLevel[0.5]],
+							ToString[type, StandardForm]
+						}
 					}, 
 					Alignment -> {Left, Top}
 				],
 				Failure[tag, assoc]
 			] /; msg =!= Missing["KeyAbsent", "MessageTemplate"] && 
-					msgParam =!= Missing["KeyAbsent", "MessageParameters"]
+				msgParam =!= Missing["KeyAbsent", "MessageParameters"] && 
+				msgParam =!= Missing["KeyAbsent", "Type"]
 		]
 ]
 
@@ -1011,12 +1024,13 @@ throwException[
 		}
 		,
 		Throw[
-			Failure[tag,
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :>
 						MessageName[CellsToTeXException, messageName],
 					"MessageParameters" ->
-						List @@ HoldForm /@ HoldComplete[thrownBy, tag, vals]
+						List @@ HoldForm /@ HoldComplete[thrownBy, tag, vals],
+					"Type" -> {types, type}
 				]
 			],
 			tag
@@ -1112,7 +1126,11 @@ rethrowException[rethrownBy_, opts:OptionsPattern[]] :=
 								HoldComplete[value]
 							]&;
 						
-						If[!MatchQ[value, Failure[tag, _Association]],
+						If[
+							!MatchQ[value,
+								Failure[CellsToTeXException, _Association]
+							]
+						(* then *),
 							throwInvValExc["NonFailureObject"]
 						];
 						
@@ -1137,17 +1155,18 @@ rethrowException[rethrownBy_, opts:OptionsPattern[]] :=
 								]
 							}
 							,
-							assoc = Append[assoc,
+							assoc = Append[assoc, {
 								"MessageParameters" -> {
 									HoldForm[rethrownBy],
 									HoldForm[newTag],
 									Sequence @@ Drop[msgParams, 2],
 									Sequence @@ HoldForm /@
 										additionalMessageParameters
-								}
-							];
+								},
+								"Type" -> List @@ newTag
+							}];
 							
-							Throw[Failure[newTag, assoc], newTag]
+							Throw[Failure[CellsToTeXException, assoc], newTag]
 						]
 					]
 				]

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -13,6 +13,20 @@ $ContextPath =
 	Join[{"CellsToTeX`Configuration`", "CellsToTeX`Backports`"}, $ContextPath]
 
 
+(*	In tests we use pattern matching on contents of Association, it works since
+	Mathematica v10.4, and for backported Association for versions < 10.0,
+	but not for versions from 10.0 to 10.3, so for this versions we normalize
+	Associations. *)
+normalAssoc =
+	If[10 <= $VersionNumber < 10.4,
+		Module[{association},
+			(# /. assoc_Association :> association @@ Normal[assoc])&
+		]
+	(* else *),
+		Identity
+	]
+
+
 (* ::Section:: *)
 (*Tests*)
 
@@ -366,14 +380,14 @@ With[
 	}
 	,
 	TestMatch[
-		CellToTeX[Cell[BoxData["contents"]]]
+		CellToTeX[Cell[BoxData["contents"]]] // normalAssoc
 		,
 		Failure[CellsToTeXException["Missing", "CellStyle"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingCellStyle,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -396,14 +410,15 @@ With[
 	}
 	,
 	TestMatch[
-		CellToTeX[Cell[BoxData["contents"], "testUnsupportedStyle"]]
+		CellToTeX[Cell[BoxData["contents"], "testUnsupportedStyle"]] //
+			normalAssoc
 		,
 		Failure[CellsToTeXException["Unsupported", "CellStyle"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -427,14 +442,14 @@ With[
 		CellToTeX[
 			Cell["contents", "Input"],
 			"ProcessorOptions" -> {"FormatType" -> testFormatType}
-		]
+		] // normalAssoc
 		,
 		Failure[CellsToTeXException["Unsupported", "FormatType"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -459,14 +474,14 @@ With[
 			BoxData[testUnsupportedBox],
 			"Style" -> "Output",
 			"ProcessorOptions" -> {"BoxRules" -> {testSupportedBox[b_] :> b}}
-		]
+		] // normalAssoc
 		,
 		Failure[CellsToTeXException["Unsupported", "Box"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -499,14 +514,14 @@ Block[
 			CellToTeX[
 				BoxData[RowBox[{"testUndefinedSymbol"}]],
 				"Style" -> "Input"
-			]
+			] // normalAssoc
 			,
 			Failure[CellsToTeXException["Unsupported", "AnnotationType"],
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
 					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 				]
-			]
+			] // normalAssoc
 			,
 			{heldMessage}
 			,
@@ -538,14 +553,14 @@ With[
 				ShowCellLabel -> True
 			],
 			"ProcessorOptions" -> {"BoxRules" -> {testSupportedBox -> ""}}
-		]
+		] // normalAssoc
 		,
 		Failure[CellsToTeXException["Unsupported", "Box"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -593,14 +608,14 @@ With[
 		CellToTeX[
 			Cell[BoxData["contents"], "Print"],
 			"Processor" -> trackCellIndexProcessor
-		]
+		] // normalAssoc
 		,
 		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,
@@ -638,14 +653,14 @@ With[
 		CellToTeX[
 			Cell[BoxData["contents"], "Message"],
 			"Processor" -> Identity
-		]
+		] // normalAssoc
 		,
 		Failure[CellsToTeXException["Missing", "Keys", "ProcessorResult"],
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcRes,
 				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
 			]
-		]
+		] // normalAssoc
 		,
 		{heldMessage}
 		,

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -382,10 +382,11 @@ With[
 	TestMatch[
 		CellToTeX[Cell[BoxData["contents"]]] // normalAssoc
 		,
-		Failure[CellsToTeXException["Missing", "CellStyle"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingCellStyle,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Missing", "CellStyle"}
 			]
 		] // normalAssoc
 		,
@@ -413,10 +414,11 @@ With[
 		CellToTeX[Cell[BoxData["contents"], "testUnsupportedStyle"]] //
 			normalAssoc
 		,
-		Failure[CellsToTeXException["Unsupported", "CellStyle"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Unsupported", "CellStyle"}
 			]
 		] // normalAssoc
 		,
@@ -444,10 +446,11 @@ With[
 			"ProcessorOptions" -> {"FormatType" -> testFormatType}
 		] // normalAssoc
 		,
-		Failure[CellsToTeXException["Unsupported", "FormatType"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Unsupported", "FormatType"}
 			]
 		] // normalAssoc
 		,
@@ -476,10 +479,11 @@ With[
 			"ProcessorOptions" -> {"BoxRules" -> {testSupportedBox[b_] :> b}}
 		] // normalAssoc
 		,
-		Failure[CellsToTeXException["Unsupported", "Box"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Unsupported", "Box"}
 			]
 		] // normalAssoc
 		,
@@ -516,10 +520,11 @@ Block[
 				"Style" -> "Input"
 			] // normalAssoc
 			,
-			Failure[CellsToTeXException["Unsupported", "AnnotationType"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
-					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+					"Type" -> {"Unsupported", "AnnotationType"}
 				]
 			] // normalAssoc
 			,
@@ -555,10 +560,11 @@ With[
 			"ProcessorOptions" -> {"BoxRules" -> {testSupportedBox -> ""}}
 		] // normalAssoc
 		,
-		Failure[CellsToTeXException["Unsupported", "Box"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Unsupported", "Box"}
 			]
 		] // normalAssoc
 		,
@@ -610,10 +616,11 @@ With[
 			"Processor" -> trackCellIndexProcessor
 		] // normalAssoc
 		,
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 			]
 		] // normalAssoc
 		,
@@ -655,10 +662,11 @@ With[
 			"Processor" -> Identity
 		] // normalAssoc
 		,
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorResult"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcRes,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Missing", "Keys", "ProcessorResult"}
 			]
 		] // normalAssoc
 		,

--- a/CellsToTeX/Tests/Integration/CellsToTeXPreamble.mt
+++ b/CellsToTeX/Tests/Integration/CellsToTeXPreamble.mt
@@ -90,14 +90,14 @@ Module[{unsupportedValue},
 				]
 		}
 		,
-		TestMatch[
+		Test[
 			CellsToTeXPreamble["Gobble" -> unsupportedValue]
 			,
-			Failure[
-				CellsToTeXException["Unsupported", "OptionValue", "Gobble"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
-					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+					"Type" -> {"Unsupported", "OptionValue", "Gobble"}
 				]
 			]
 			,
@@ -161,16 +161,14 @@ Module[{unsupportedValue},
 				]
 		}
 		,
-		TestMatch[
+		Test[
 			CellsToTeXPreamble["UseListings" -> unsupportedValue]
 			,
-			Failure[
-				CellsToTeXException[
-					"Unsupported", "OptionValue", "UseListings"
-				],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
-					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+					"Type" -> {"Unsupported", "OptionValue", "UseListings"}
 				]
 			]
 			,
@@ -211,15 +209,14 @@ Module[{unsupportedValue},
 				]
 		}
 		,
-		TestMatch[
+		Test[
 			CellsToTeXPreamble["TeXOptions" -> unsupportedValue]
 			,
-			Failure[
-				CellsToTeXException["Unsupported", "OptionValue", "TeXOptions"]
-				,
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
-					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+					"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+					"Type" -> {"Unsupported", "OptionValue", "TeXOptions"}
 				]
 			]
 			,
@@ -268,16 +265,14 @@ With[
 			]
 	}
 	,
-	TestMatch[
+	Test[
 		CellsToTeXPreamble["TeXMathReplacement" -> "unsupportedValue"]
 		,
-		Failure[
-			CellsToTeXException[
-				"Unsupported", "OptionValue", "TeXMathReplacement"
-			],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
-				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]]
+				"MessageParameters" -> (List @@@ heldMessage)[[1, 2;;]],
+				"Type" -> {"Unsupported", "OptionValue", "TeXMathReplacement"}
 			]
 		]
 		,

--- a/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
+++ b/CellsToTeX/Tests/Integration/annotateSyntaxProcessor.mt
@@ -536,7 +536,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
 				"MessageParameters" -> {
@@ -551,7 +551,8 @@ Test[
 						"CommonestTypesAsTeXOptions", "StringBoxToTypes",
 						"AnnotateComments"
 					}
-				}
+				},
+				"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 			]
 		],
 		CellsToTeXException["Missing", "Keys", "ProcessorArgument"]
@@ -583,7 +584,7 @@ With[
 			]
 			,
 			HoldComplete @@ {
-				Failure[CellsToTeXException["Unsupported", "AnnotationType"],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::unsupported,
 						"MessageParameters" -> {
@@ -594,7 +595,8 @@ With[
 							HoldForm @ "AnnotationType",
 							HoldForm @ "UndefinedSymbol",
 							HoldForm @ {"testSupportedAnnotation"}
-						}
+						},
+						"Type" -> {"Unsupported", "AnnotationType"}
 					]
 				],
 				CellsToTeXException["Unsupported", "AnnotationType"]
@@ -625,10 +627,7 @@ With[
 		]
 		,
 		HoldComplete @@ {
-			Failure[
-				CellsToTeXException[
-					"Unsupported", "OptionValue", "CommonestTypesAsTeXOptions"
-				],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
 					"MessageParameters" -> {
@@ -640,6 +639,10 @@ With[
 						HoldForm @ "OptionValue",
 						HoldForm @ "testUnsupportedOptVal",
 						HoldForm @ {True, "ASCII", False}
+					},
+					"Type" -> {
+						"Unsupported", "OptionValue",
+						"CommonestTypesAsTeXOptions"
 					}
 				]
 			],

--- a/CellsToTeX/Tests/Integration/extractCellOptionsProcessor.mt
+++ b/CellsToTeX/Tests/Integration/extractCellOptionsProcessor.mt
@@ -85,7 +85,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
 				"MessageParameters" -> {
@@ -96,7 +96,8 @@ Test[
 					HoldForm @ "Keys",
 					HoldForm @ {"Boxes"},
 					HoldForm @ {}
-				}
+				},
+				"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 			]
 		],
 		CellsToTeXException["Missing", "Keys", "ProcessorArgument"]

--- a/CellsToTeX/Tests/Integration/fullNotebooks.mt
+++ b/CellsToTeX/Tests/Integration/fullNotebooks.mt
@@ -81,7 +81,7 @@ Test[
 
 
 Block[{$cellStyleOptions = $cellStyleOptions, Export = #1&},
-	Test[
+	UsingFrontEnd @ Test[
 		$cellStyleOptions =
 			Join[
 				{

--- a/CellsToTeX/Tests/Integration/mmaCellGraphicsProcessor.mt
+++ b/CellsToTeX/Tests/Integration/mmaCellGraphicsProcessor.mt
@@ -81,7 +81,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
 				"MessageParameters" -> {
@@ -92,7 +92,8 @@ Test[
 					HoldForm @ "Keys",
 					HoldForm @ {"FileName", "Style", "TeXOptions"},
 					HoldForm @ {}
-				}
+				},
+				"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 			]
 		],
 		CellsToTeXException["Missing", "Keys", "ProcessorArgument"]

--- a/CellsToTeX/Tests/Integration/processorDataLookup.mt
+++ b/CellsToTeX/Tests/Integration/processorDataLookup.mt
@@ -57,8 +57,7 @@ Block[{testProcessor, testVar, a, b, c},
 		]
 		,
 		HoldComplete @@ {
-			Failure[
-				CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missingProcArg,
 					"MessageParameters" -> {
@@ -70,7 +69,8 @@ Block[{testProcessor, testVar, a, b, c},
 						HoldForm @ "Keys",
 						HoldForm @ {"c"},
 						HoldForm @ {"a"}
-					}
+					},
+					"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys", "ProcessorArgument"]

--- a/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
+++ b/CellsToTeX/Tests/Integration/toInputFormProcessor.mt
@@ -110,7 +110,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Missing", "Keys", "ProcessorArgument"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::missingProcArg,
 				"MessageParameters" -> {
@@ -121,7 +121,8 @@ Test[
 					HoldForm @ "Keys",
 					HoldForm @ {"Boxes"},
 					HoldForm @ {}
-				}
+				},
+				"Type" -> {"Missing", "Keys", "ProcessorArgument"}
 			]
 		],
 		CellsToTeXException["Missing", "Keys", "ProcessorArgument"]
@@ -141,7 +142,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Invalid", "Boxes"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::invalid,
 				"MessageParameters" -> {
@@ -150,7 +151,8 @@ Test[
 					HoldForm @ CellsToTeXException["Invalid", "Boxes"],
 					HoldForm @ "Boxes",
 					HoldForm @ RowBox[{"f", "["}]
-				}
+				},
+				"Type" -> {"Invalid", "Boxes"}
 			]
 		],
 		CellsToTeXException["Invalid", "Boxes"]
@@ -173,7 +175,7 @@ Block[{FrontEndExecute = $Failed&},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Failed", "Parser"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::failed,
 					"MessageParameters" -> {
@@ -184,7 +186,8 @@ Block[{FrontEndExecute = $Failed&},
 							FrontEnd`UndocumentedTestFEParserPacket[
 								"a^b", False
 							]
-					}
+					},
+					"Type" -> {"Failed", "Parser"}
 				]
 			],
 			CellsToTeXException["Failed", "Parser"]

--- a/CellsToTeX/Tests/Unit/CellToTeX.mt
+++ b/CellsToTeX/Tests/Unit/CellToTeX.mt
@@ -162,7 +162,7 @@ moduleWithMockedFunctions[{testContents},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Unsupported", "CellStyle"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
 					"MessageParameters" -> {
@@ -174,7 +174,8 @@ moduleWithMockedFunctions[{testContents},
 						HoldForm @ "CellStyle",
 						HoldForm @ "testUnsupportedCellStyle",
 						HoldForm @ "testCellStyle"
-					}
+					},
+					"Type" -> {"Unsupported", "CellStyle"}
 				]
 			],
 			CellsToTeXException["Unsupported", "CellStyle"]
@@ -530,7 +531,7 @@ moduleWithMockedFunctions[{testContents},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "CellStyle"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missingCellStyle,
 					"MessageParameters" -> {
@@ -538,7 +539,8 @@ moduleWithMockedFunctions[{testContents},
 							CellToTeX[testContents, "Style" -> Automatic],
 						HoldForm @ CellsToTeXException["Missing", "CellStyle"],
 						HoldForm @ testContents
-					}
+					},
+					"Type" -> {"Missing", "CellStyle"}
 				]
 			],
 			CellsToTeXException["Missing", "CellStyle"]

--- a/CellsToTeX/Tests/Unit/addIncorrectArgsDefinition.mt
+++ b/CellsToTeX/Tests/Unit/addIncorrectArgsDefinition.mt
@@ -67,19 +67,7 @@ Module[{testFunc, testResult, testArg1, testArg2, oldDownValues},
 			HoldComplete
 		]
 		,
-		HoldComplete @@ {
-			Failure[CellsToTeXException["Error", "IncorrectArguments"],
-				Association[
-					"MessageTemplate" :> CellsToTeXException::error,
-					"MessageParameters" -> {
-						HoldForm @ testFunc[testArg1, testArg2],
-						HoldForm @
-							CellsToTeXException["Error", "IncorrectArguments"]
-					}
-				]
-			],
-			CellsToTeXException["Error", "IncorrectArguments"]
-		}
+		expectedIncorrectArgsError[testFunc[testArg1, testArg2]]
 		,
 		TestID -> "Symbol: testFunction evaluation: incorrect args"
 	]
@@ -123,7 +111,7 @@ Block[{testSym, testOtherSym},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Error", "UnwantedEvaluation"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
@@ -131,7 +119,8 @@ Block[{testSym, testOtherSym},
 						HoldForm @
 							CellsToTeXException["Error", "UnwantedEvaluation"],
 						HoldForm @ testSym
-					}
+					},
+					"Type" -> {"Error", "UnwantedEvaluation"}
 				]
 			],
 			CellsToTeXException["Error", "UnwantedEvaluation"]
@@ -169,14 +158,15 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Error", "NotSymbolName"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::error,
 				"MessageParameters" -> {
 					HoldForm @ addIncorrectArgsDefinition["not a symbol name"],
 					HoldForm @ CellsToTeXException["Error", "NotSymbolName"],
 					HoldForm @ "not a symbol name"
-				}
+				},
+				"Type" -> {"Error", "NotSymbolName"}
 			]
 		],
 		CellsToTeXException["Error", "NotSymbolName"]

--- a/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
+++ b/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
@@ -71,7 +71,7 @@ withMockedFunctions@With[
 			testLookedupStringRule,
 			HoldPattern[
 				Verbatim[Pattern][
-					charPattName_, RegularExpression["[^[:ascii:]]"]
+					charPattName_, RegularExpression["[^\\x00-\\x7F]"]
 				] :>
 					testLookedupNonASCIIHandler[charPattName_]
 			]
@@ -119,7 +119,7 @@ withMockedFunctions@With[
 		newStringRules = {
 			HoldPattern[
 				Verbatim[Pattern][
-					charPattName_, RegularExpression["[^[:ascii:]]"]
+					charPattName_, RegularExpression["[^\\x00-\\x7F]"]
 				] :>
 					testLookedupNonASCIIHandler[charPattName_]
 			]

--- a/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
+++ b/CellsToTeX/Tests/Unit/boxRulesProcessor.mt
@@ -69,10 +69,12 @@ withMockedFunctions@With[
 	{
 		newStringRules = {
 			testLookedupStringRule,
-			Verbatim[Pattern][
-				charPattName_, RegularExpression["[^[:ascii:]]"]
-			] :>
-				testLookedupNonASCIIHandler[charPattName_]
+			HoldPattern[
+				Verbatim[Pattern][
+					charPattName_, RegularExpression["[^[:ascii:]]"]
+				] :>
+					testLookedupNonASCIIHandler[charPattName_]
+			]
 		}
 	}
 	,
@@ -115,10 +117,12 @@ withMockedFunctions@With[
 withMockedFunctions@With[
 	{
 		newStringRules = {
-			Verbatim[Pattern][
-				charPattName_, RegularExpression["[^[:ascii:]]"]
-			] :>
-				testLookedupNonASCIIHandler[charPattName_]
+			HoldPattern[
+				Verbatim[Pattern][
+					charPattName_, RegularExpression["[^[:ascii:]]"]
+				] :>
+					testLookedupNonASCIIHandler[charPattName_]
+			]
 		}
 	}
 	,

--- a/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
+++ b/CellsToTeX/Tests/Unit/boxesToInputFormBoxes.mt
@@ -132,7 +132,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Invalid", "Boxes"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::invalid,
 				"MessageParameters" -> {
@@ -140,7 +140,8 @@ Test[
 					HoldForm @ CellsToTeXException["Invalid", "Boxes"],
 					HoldForm @ "Boxes",
 					HoldForm @ RowBox[{"f", "["}]
-				}
+				},
+				"Type" -> {"Invalid", "Boxes"}
 			]
 		],
 		CellsToTeXException["Invalid", "Boxes"]
@@ -163,7 +164,7 @@ Block[{FrontEndExecute = $Failed&},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Failed", "Parser"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::failed,
 					"MessageParameters" -> {
@@ -174,7 +175,8 @@ Block[{FrontEndExecute = $Failed&},
 							FrontEnd`UndocumentedTestFEParserPacket[
 								"a^b", False
 							]
-					}
+					},
+					"Type" -> {"Failed", "Parser"}
 				]
 			],
 			CellsToTeXException["Failed", "Parser"]

--- a/CellsToTeX/Tests/Unit/boxesToString.mt
+++ b/CellsToTeX/Tests/Unit/boxesToString.mt
@@ -584,7 +584,7 @@ Test[
 	]
 	,
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Unsupported", "FormatType"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::unsupported,
 				"MessageParameters" -> {
@@ -594,7 +594,8 @@ Test[
 					HoldForm @ "FormatType",
 					HoldForm @ TeXForm,
 					HoldForm @ {InputForm, OutputForm}
-				}
+				},
+				"Type" -> {"Unsupported", "FormatType"}
 			]
 		],
 		CellsToTeXException["Unsupported", "FormatType"]

--- a/CellsToTeX/Tests/Unit/charToTeX.mt
+++ b/CellsToTeX/Tests/Unit/charToTeX.mt
@@ -9,7 +9,8 @@ BeginPackage["CellsToTeX`Tests`Unit`charToTeX`", {"MUnit`"}]
 
 Get["CellsToTeX`"]
 
-PrependTo[$ContextPath, "CellsToTeX`Configuration`"]
+$ContextPath =
+	Join[{"CellsToTeX`Configuration`", "CellsToTeX`Backports`"}, $ContextPath]
 
 
 (* ::Section:: *)

--- a/CellsToTeX/Tests/Unit/charToTeX.mt
+++ b/CellsToTeX/Tests/Unit/charToTeX.mt
@@ -84,8 +84,7 @@ Module[{unsupportedFontWeight},
 		]
 		,
 		HoldComplete @@ {
-			Failure[
-				CellsToTeXException["Unsupported", "OptionValue", FontWeight],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::unsupported,
 					"MessageParameters" -> {
@@ -98,7 +97,8 @@ Module[{unsupportedFontWeight},
 						HoldForm @ "OptionValue",
 						HoldForm @ unsupportedFontWeight,
 						HoldForm @ {Plain, Bold}
-					}
+					},
+					"Type" -> {"Unsupported", "OptionValue", FontWeight}
 				]
 			],
 			CellsToTeXException["Unsupported", "OptionValue", FontWeight]

--- a/CellsToTeX/Tests/Unit/dataLookup.mt
+++ b/CellsToTeX/Tests/Unit/dataLookup.mt
@@ -139,7 +139,7 @@ Block[{a},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -148,7 +148,8 @@ Block[{a},
 						HoldForm["Keys"],
 						HoldForm[{"a"}],
 						HoldForm[{}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]
@@ -169,7 +170,7 @@ Block[{a, b, c},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -178,7 +179,8 @@ Block[{a, b, c},
 						HoldForm["Keys"],
 						HoldForm[{"c"}],
 						HoldForm[{"a"}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]
@@ -199,7 +201,7 @@ Block[{a, b, c, d, e},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -208,7 +210,8 @@ Block[{a, b, c, d, e},
 						HoldForm["Keys"],
 						HoldForm[{"e"}],
 						HoldForm[{"a", "c"}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]
@@ -229,7 +232,7 @@ Block[{a, b, c, d},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -238,7 +241,8 @@ Block[{a, b, c, d},
 						HoldForm["Keys"],
 						HoldForm[{"d"}],
 						HoldForm[{"a"}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]
@@ -316,7 +320,7 @@ Block[{a, b, c},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -325,7 +329,8 @@ Block[{a, b, c},
 						HoldForm["Keys"],
 						HoldForm[{"a", "c"}],
 						HoldForm[{}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]
@@ -346,7 +351,7 @@ Block[{a, b, c},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", "Keys"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -355,7 +360,8 @@ Block[{a, b, c},
 						HoldForm["Keys"],
 						HoldForm[{"c"}],
 						HoldForm[{"a"}]
-					}
+					},
+					"Type" -> {"Missing", "Keys"}
 				]
 			],
 			CellsToTeXException["Missing", "Keys"]

--- a/CellsToTeX/Tests/Unit/exportProcessor.mt
+++ b/CellsToTeX/Tests/Unit/exportProcessor.mt
@@ -267,7 +267,7 @@ withMockedFunctions[
 		,
 		With[{testCell = testCell, testData = testData},
 			HoldComplete @@ {
-				Failure[CellsToTeXException["Failed", "Export"],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::failed,
 						"MessageParameters" -> {
@@ -277,7 +277,8 @@ withMockedFunctions[
 								testLookedupFileNameGeneratorResult, testCell,
 								testLookedupExportFormat, testData
 							]
-						}
+						},
+						"Type" -> {"Failed", "Export"}
 					]
 				],
 				CellsToTeXException["Failed", "Export"]

--- a/CellsToTeX/Tests/Unit/rethrowException.mt
+++ b/CellsToTeX/Tests/Unit/rethrowException.mt
@@ -38,14 +38,15 @@ Module[{testVar, value, type, thrownBy},
 	Test[
 		Catch[
 			rethrowException[testVar = "Evaluation leaked"] @ Throw[
-				Failure[CellsToTeXException[type],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::msg,
 						"MessageParameters" -> {
 							HoldForm @ thrownBy,
 							HoldForm @ CellsToTeXException[type],
 							HoldForm @ value
-						}
+						},
+						"Type" -> {type}
 					]
 				],
 				CellsToTeXException[type]
@@ -57,14 +58,15 @@ Module[{testVar, value, type, thrownBy},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[type],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::msg,
 					"MessageParameters" -> {
 						HoldForm[testVar = "Evaluation leaked"],
 						HoldForm @ CellsToTeXException[type],
 						HoldForm @ value
-					}
+					},
+					"Type" -> {type}
 				]
 			],
 			CellsToTeXException[type]
@@ -96,10 +98,7 @@ Module[{rethrownBy, nonFailure, type},
 		]
 		,
 		HoldComplete @@ {
-			Failure[
-				CellsToTeXException[
-					"Error", "InvalidExceptionValue", "NonFailureObject"
-				],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
@@ -112,7 +111,9 @@ Module[{rethrownBy, nonFailure, type},
 							"NonFailureObject"
 						],
 						HoldForm @ nonFailure
-					}
+					},
+					"Type" ->
+						{"Error", "InvalidExceptionValue", "NonFailureObject"}
 				]
 			],
 			CellsToTeXException[
@@ -127,7 +128,7 @@ Module[{rethrownBy, type},
 	Test[
 		Catch[
 			rethrowException[rethrownBy] @ Throw[
-				Failure[CellsToTeXException[type],
+				Failure[CellsToTeXException,
 					Association["MessageTemplate" :> CellsToTeXException::msg]
 				],
 				CellsToTeXException[type]
@@ -139,16 +140,12 @@ Module[{rethrownBy, type},
 		]
 		,
 		HoldComplete @@ {
-			Failure[
-				CellsToTeXException[
-					"Error", "InvalidExceptionValue", "NoMessageParameters"
-				]
-				,
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm @ rethrowException[rethrownBy] @ Throw[
-							Failure[CellsToTeXException[type],
+							Failure[CellsToTeXException,
 								Association[
 									"MessageTemplate" :>
 										CellsToTeXException::msg
@@ -160,11 +157,14 @@ Module[{rethrownBy, type},
 							"Error", "InvalidExceptionValue",
 							"NoMessageParameters"
 						],
-						HoldForm[#]& @ Failure[CellsToTeXException[type],
+						HoldForm[#]& @ Failure[CellsToTeXException,
 							Association[
 								"MessageTemplate" :> CellsToTeXException::msg
 							]
 						]
+					},
+					"Type" -> {
+						"Error", "InvalidExceptionValue", "NoMessageParameters"
 					}
 				]
 			],
@@ -212,14 +212,15 @@ Module[
 				"MessageTemplate" :> CellsToTeXException::newMsg,
 				"AdditionalMessageParameters" -> {additionalVal}
 			] @ Throw[
-				Failure[CellsToTeXException[type, subType],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::msg,
 						"MessageParameters" -> {
 							HoldForm @ thrownBy,
 							HoldForm @ CellsToTeXException[type, subType],
 							HoldForm @ value
-						}
+						},
+						"Type" -> {type, subType}
 					]
 				],
 				CellsToTeXException[type, subType]
@@ -231,7 +232,7 @@ Module[
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[type, subType, additionalType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::newMsg,
 					"MessageParameters" -> {
@@ -240,7 +241,8 @@ Module[
 							CellsToTeXException[type, subType, additionalType],
 						HoldForm @ value,
 						HoldForm @ additionalVal
-					}
+					},
+					"Type" -> {type, subType, additionalType}
 				]
 			],
 			CellsToTeXException[type, subType, additionalType]
@@ -270,14 +272,15 @@ Module[
 				"MessageTemplate" :> CellsToTeXException::newMsg,
 				"AdditionalMessageParameters" -> {additionalVal}
 			] @ Throw[
-				Failure[CellsToTeXException[type],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::msg,
 						"MessageParameters" -> {
 							HoldForm @ thrownBy,
 							HoldForm @ CellsToTeXException[type],
 							HoldForm @ value
-						}
+						},
+						"Type" -> {type}
 					]
 				],
 				CellsToTeXException[type]
@@ -289,14 +292,15 @@ Module[
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[type],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::msg,
 					"MessageParameters" -> {
 						HoldForm @ thrownBy,
 						HoldForm @ CellsToTeXException[type],
 						HoldForm @ value
-					}
+					},
+					"Type" -> {type}
 				]
 			],
 			CellsToTeXException[type]

--- a/CellsToTeX/Tests/Unit/throwException.mt
+++ b/CellsToTeX/Tests/Unit/throwException.mt
@@ -30,13 +30,14 @@ Module[{thrownBy, errType},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -58,14 +59,15 @@ Module[{thrownBy, errType, val},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType],
 						HoldForm[val]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -87,14 +89,15 @@ Module[{thrownBy, errType, errSubType, val},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType, errSubType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType, errSubType],
 						HoldForm[val]
-					}
+					},
+					"Type" -> {errType, errSubType}
 				]
 			],
 			CellsToTeXException[errType, errSubType]
@@ -116,14 +119,15 @@ Module[{thrownBy, val},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["testExceptionType"],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException["testExceptionType"],
 						HoldForm[val]
-					}
+					},
+					"Type" -> {"testExceptionType"}
 				]
 			],
 			CellsToTeXException["testExceptionType"]
@@ -145,14 +149,15 @@ Module[{thrownBy, errType, val},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType],
 						HoldForm[val]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -174,7 +179,7 @@ Module[{thrownBy, errType, val1, val2},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
@@ -182,7 +187,8 @@ Module[{thrownBy, errType, val1, val2},
 						HoldForm @ CellsToTeXException[errType],
 						HoldForm[val1],
 						HoldForm[val2]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -206,7 +212,7 @@ Module[{thrownBy, errType, testVar1, val2},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
@@ -214,7 +220,8 @@ Module[{thrownBy, errType, testVar1, val2},
 						HoldForm @ CellsToTeXException[errType],
 						HoldForm[testVar1 = "Evaluation leaked"],
 						HoldForm[val2]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -243,13 +250,14 @@ Module[{errType, testVar},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
 						HoldForm[testVar = "Evaluation leaked"],
 						HoldForm @ CellsToTeXException[errType]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -278,14 +286,15 @@ Module[{thrownBy, errType, val},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::messageName,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType],
 						HoldForm[val]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -307,13 +316,14 @@ Module[{thrownBy, errType},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException[errType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::messageName,
 					"MessageParameters" -> {
 						HoldForm[thrownBy],
 						HoldForm @ CellsToTeXException[errType]
-					}
+					},
+					"Type" -> {errType}
 				]
 			],
 			CellsToTeXException[errType]
@@ -339,7 +349,7 @@ Module[{thrownBy, elementType, subType, expr},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Failed", elementType, subType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::failed,
 					"MessageParameters" -> {
@@ -348,7 +358,8 @@ Module[{thrownBy, elementType, subType, expr},
 							"Failed", elementType, subType
 						],
 						HoldForm[expr]
-					}
+					},
+					"Type" -> {"Failed", elementType, subType}
 				]
 			],
 			CellsToTeXException["Failed", elementType, subType]
@@ -372,7 +383,7 @@ Module[{thrownBy, elementType, subType, missing, available},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Missing", elementType, subType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::missing,
 					"MessageParameters" -> {
@@ -383,7 +394,8 @@ Module[{thrownBy, elementType, subType, missing, available},
 						HoldForm[elementType],
 						HoldForm[missing],
 						HoldForm[available]
-					}
+					},
+					"Type" -> {"Missing", elementType, subType}
 				]
 			],
 			CellsToTeXException["Missing", elementType, subType]
@@ -407,7 +419,7 @@ Module[{thrownBy, elementType, subType, invalid},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Invalid", elementType, subType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::invalid,
 					"MessageParameters" -> {
@@ -417,7 +429,8 @@ Module[{thrownBy, elementType, subType, invalid},
 						],
 						HoldForm[elementType],
 						HoldForm[invalid]
-					}
+					},
+					"Type" -> {"Invalid", elementType, subType}
 				]
 			],
 			CellsToTeXException["Invalid", elementType, subType]
@@ -450,8 +463,7 @@ Module[
 			]
 			,
 			HoldComplete @@ {
-				Failure[
-					CellsToTeXException["Unsupported", elementType, subType],
+				Failure[CellsToTeXException,
 					Association[
 						"MessageTemplate" :> CellsToTeXException::unsupported,
 						"MessageParameters" -> {
@@ -462,7 +474,8 @@ Module[
 							HoldForm[elementType],
 							HoldForm[{unsupported}],
 							HoldForm[{prettifyPatternsResult}]
-						}
+						},
+						"Type" -> {"Unsupported", elementType, subType}
 					]
 				],
 				CellsToTeXException["Unsupported", elementType, subType]
@@ -487,7 +500,7 @@ Module[{thrownBy, elementType, subType, val1, val2},
 		]
 		,
 		HoldComplete @@ {
-			Failure[CellsToTeXException["Error", elementType, subType],
+			Failure[CellsToTeXException,
 				Association[
 					"MessageTemplate" :> CellsToTeXException::error,
 					"MessageParameters" -> {
@@ -497,7 +510,8 @@ Module[{thrownBy, elementType, subType, val1, val2},
 						],
 						HoldForm[val1],
 						HoldForm[val2]
-					}
+					},
+					"Type" -> {"Error", elementType, subType}
 				]
 			],
 			CellsToTeXException["Error", elementType, subType]

--- a/CellsToTeX/Tests/Utilities.m
+++ b/CellsToTeX/Tests/Utilities.m
@@ -67,14 +67,15 @@ SetAttributes[expectedIncorrectArgsError, HoldAllComplete]
 
 expectedIncorrectArgsError[functionCall_] :=
 	HoldComplete @@ {
-		Failure[CellsToTeXException["Error", "IncorrectArguments"],
+		Failure[CellsToTeXException,
 			Association[
 				"MessageTemplate" :> CellsToTeXException::error,
 				"MessageParameters" -> {
 					HoldForm @ functionCall,
 					HoldForm @
 						CellsToTeXException["Error", "IncorrectArguments"]
-				}
+				},
+				"Type" -> {"Error", "IncorrectArguments"}
 			]
 		],
 		CellsToTeXException["Error", "IncorrectArguments"]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,10 +1,10 @@
 (* Paclet Info File *)
 
-(* created 2016/01/30*)
+(* created 2016/05/20*)
 
 Paclet[
     Name -> "CellsToTeX",
-    Version -> "0.1.4",
+    Version -> "0.2.0",
     MathematicaVersion -> "6+",
     Description -> "Convert Mathematica cells to TeX, retaining formatting",
     Creator -> "Jakub Kuczmarski",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To load CellsToTeX package evaluate: ``Needs["CellsToTeX`"]``.
 ### Manual installation
 
 1. Download latest released
-   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.1.4/CellsToTeX.zip)
+   [CellsToTeX.zip](https://github.com/jkuczm/MathematicaCellsToTeX/releases/download/v0.2.0/CellsToTeX.zip)
    file.
 
 2. Extract downloaded `CellsToTeX.zip` to any directory which is on


### PR DESCRIPTION
Backward incompatible change: `CellsToTeXException` is now always used as tag of `Failure` object, association in `Failure` contains now `"Type"` key with type of thrown exception.

Version bump 0.2.0