### PR TITLE
Fix identifier escaping

### DIFF
--- a/CellsToTeX/CellsToTeX.m
+++ b/CellsToTeX/CellsToTeX.m
@@ -393,6 +393,19 @@ Begin["`Internal`"]
 ClearAll["`*"]
 
 
+$texEscape::usage =
+"\
+$texEscape \
+is a String used to escape a character in non-verbatim TeX code."
+
+
+$texSpecialChars::usage =
+"\
+$texSpecialChars \
+is a string pattern matching characters that need to be escaped in \
+non-verbatim TeX code."
+
+
 throwException::usage =
 "\
 throwException[thrownBy, {errType, errSubtype, ...}, {val1, val2, ...}] or \
@@ -978,6 +991,20 @@ addIncorrectArgsDefinition /@
 
 
 (* ::Subsubsection:: *)
+(*$texEscape*)
+
+
+$texEscape = "\\"
+
+
+(* ::Subsubsection:: *)
+(*$texSpecialChars*)
+
+
+$texSpecialChars = "#" | "%" | "{" | "}" | "\\"
+
+
+(* ::Subsubsection:: *)
 (*throwException*)
 
 
@@ -1404,7 +1431,10 @@ annotationTypesToKeyVal[
 	symToTypes:{(_Rule | _RuleDelayed)...},
 	typesToKeys:{(_Rule | _RuleDelayed)...}
 ] :=
-	Replace[#[[1, 2]], typesToKeys] -> #[[All, 1]]& /@
+	(
+		Replace[#[[1, 2]], typesToKeys] ->
+			StringReplace[#[[All, 1]], c:$texSpecialChars :> $texEscape <> c]
+	)& /@
 		GatherBy[
 			Cases[
 				symToTypes,

--- a/CellsToTeX/Tests/Integration/CellToTeX.mt
+++ b/CellsToTeX/Tests/Integration/CellToTeX.mt
@@ -72,6 +72,21 @@ UsingFrontEnd @ Test[
 ]
 
 
+Test[
+	CellToTeX[
+		RowBox[{RowBox[{"#", " ", "##", " ", "#something", " ", "##4"}], "&"}],
+		"Style" -> "Input"
+	]
+	,
+	"\
+\\begin{mmaCell}[morepattern={\\#, \\#\\#, \\#something, \\#\\#4}]{Input}
+  # ## #something ##4&
+\\end{mmaCell}"
+	,
+	TestID -> "pure boxes: pure function with slots: Input"
+]
+
+
 Block[{\[Phi]1},
 	\[Phi]1[x_] := x;
 	

--- a/CellsToTeX/Tests/Unit/annotationTypesToKeyVal.mt
+++ b/CellsToTeX/Tests/Unit/annotationTypesToKeyVal.mt
@@ -71,6 +71,18 @@ Test[
 ]
 
 
+Test[
+	annotationTypesToKeyVal[
+		{"a#%" -> "Type1", "V{}\\5" -> "Type1"},
+		$testAnnotationTypeToKey
+	]
+	,
+	{"type1" -> {"a\\#\\%", "V\\{\\}\\\\5"}}
+	,
+	TestID -> "TeX special characters"
+]
+
+
 (* ::Subsection:: *)
 (*Incorrect arguments*)
 


### PR DESCRIPTION
TeX special characters in identifier names, appearing in options, are now escaped.

Fixes bug reported in #20.